### PR TITLE
fix/DPAV-555: Fixed websocket username null, now call user-detail on websocket load.

### DIFF
--- a/frontend/src/api/ws.ts
+++ b/frontend/src/api/ws.ts
@@ -11,14 +11,10 @@ export class WebSocketClient {
 
   private readonly connectionCallback: () => void | undefined;
 
-  constructor(
-    connectionCallback: () => void,
-    messageCallback: (msg: string) => void,
-    user: { username: string; displayName?: string }
-  ) {
+  constructor(connectionCallback: () => void, messageCallback: (msg: string) => void) {
     this.connectionCallback = connectionCallback;
     this.messageCallback = messageCallback;
-    this.connect(user);
+    this.connect();
   }
 
   send(message: string) {
@@ -33,13 +29,9 @@ export class WebSocketClient {
     this.ws?.close();
   }
 
-  private connect(
-    user: { username: string; displayName?: string },
-    isRestoration: boolean = false
-  ) {
-    const userQueryParam = encodeURIComponent(JSON.stringify(user));
+  private connect(isRestoration: boolean = false) {
     const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
-    const ws = new WebSocket(`${protocol}://${window.location.host}/api/ws?user=${userQueryParam}`);
+    const ws = new WebSocket(`${protocol}://${window.location.host}/api/ws`);
     ws.onopen = () => {
       this.handleOpen(isRestoration);
     };
@@ -47,7 +39,7 @@ export class WebSocketClient {
       this.handleMessage(msg);
     };
     ws.onclose = () => {
-      this.handleClose(user);
+      this.handleClose();
     };
     this.ws = ws;
   }
@@ -67,13 +59,13 @@ export class WebSocketClient {
     }
   }
 
-  private handleClose(user: { username: string; displayName?: string }) {
+  private handleClose() {
     const delay = Math.min(500 * 2 ** this.attemptCount, 32000);
     // eslint-disable-next-line no-console
     console.warn('ws connection was closed, retrying in', delay / 1000, 's');
     clearTimeout(this.timer);
     this.timer = setTimeout(() => {
-      this.connect(user, true);
+      this.connect(true);
     }, delay);
     this.attemptCount += 1;
   }

--- a/frontend/src/providers/MessagingProvider.tsx
+++ b/frontend/src/providers/MessagingProvider.tsx
@@ -25,7 +25,7 @@ export default function MessagingProvider({ children }: Readonly<PropsWithChildr
     if (!user.authenticated || !user.current) {
       return undefined;
     }
-    ws.current = new WebSocketClient(handleConnection, handleIncoming, user.current);
+    ws.current = new WebSocketClient(handleConnection, handleIncoming);
     return () => {
       ws.current?.close();
       ws.current = null;


### PR DESCRIPTION
Fixed websocket username null, now call user-detail on websocket load.

## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

Fix LISA backend not working due to unable to access variable.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Description

Removed sending up user account in search param on websocket service. Now call user-details directly on websocket within backend. Added stricter variable checks to make sure the websocket only runs if it has access to the user's details.

<!--- Describe your changes in detail -->

## How Has This Been Tested?

Tested locally, and if user has correct cookies can see that the user-details is called and returns the user object.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.