### PR TITLE
fix(dpav-555): fix fetching of oidc cookie in http requests

### DIFF
--- a/backend/src/services/auth.ts
+++ b/backend/src/services/auth.ts
@@ -46,7 +46,7 @@ export async function getUserDetails(req: Request) {
     return new User('local.user', 'local.user@example.com');
   }
 
-  const oidcCookie = req.headers.cookie['oidc-cookie'];
+  const oidcCookie = req.cookies['oidc-cookie'];
 
   if (!oidcCookie) {
     throw new AuthCookieMissingOrExpiredError();


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The OIDC cookie was not able to be retrieved in the http requests using the current code.

## Description
<!--- Describe your changes in detail -->
- Changed the retrieval of the OIDC cookie to using the cookie parser in nodejs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested locally and seems to be working.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.