### PR TITLE
fix(dpav-555): switch to sending the x auth request access token header

### DIFF
--- a/backend/src/auth/middleware.ts
+++ b/backend/src/auth/middleware.ts
@@ -1,7 +1,7 @@
 /* eslint-disable consistent-return */
 
 import { Request, Response, NextFunction } from 'express';
-import { AuthCookieMissingOrExpiredError } from '../errors';
+import { AccessTokenMissingOrExpiredError } from '../errors';
 import { settings } from '../settings';
 import { getUserDetails } from '../services/auth';
 import { User } from './user';
@@ -21,7 +21,7 @@ export function authenticate() {
       res.locals.user = await getUserDetails(req);
       next();
     } catch (error) {
-      if (error instanceof AuthCookieMissingOrExpiredError) {
+      if (error instanceof AccessTokenMissingOrExpiredError) {
         return res.status(302).json({ redirectUrl: `${settings.LANDING_PAGE_URL}/oauth2/start` });
       }
       console.log('Error authenticating user: ', error);

--- a/backend/src/errors.ts
+++ b/backend/src/errors.ts
@@ -6,9 +6,9 @@ interface ExpressError extends Error {
   statusCode?: number;
 }
 
-export class AuthCookieMissingOrExpiredError extends Error {
+export class AccessTokenMissingOrExpiredError extends Error {
   constructor() {
-    super('Error: The OIDC cookie is either not set or has expired.');
+    super('Error: The X-Auth-Request-Access-Token header is either not set or has expired.');
   }
 }
 


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously the content of the OIDC cookie was being sent across when getting the user details from the landing page api. This is incorrect and the JWT token in the X-Auth-Request-Access-Token header needs to be sent.

## Description
<!--- Describe your changes in detail -->
- Sent the value of the X-Auth-Request-Access-Token when fetching the user details.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested locally and shown to be working.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.