### PR TITLE
fix(dpav-555): fixed web socket and sign out integration

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -4,26 +4,16 @@ import { createServer } from 'http';
 // Local imports
 import app from './app';
 import { handleUpgrade } from './pubSub/server';
-import { getUserDetailsForWs } from './services/auth';
 import { settings } from './settings';
 
 const server = createServer(app);
 server.on('upgrade', async (request, socket, head) => {
-  let user;
   if (request.url !== '/api/ws') {
     socket.destroy();
     return;
   }
-  try {
-    user = await getUserDetailsForWs(request, socket);
-  } catch (error) {
-    console.log('Error fetching user details', error);
-    socket.destroy();
-  }
 
-  if (user?.email && user?.username) {
-    await handleUpgrade(request, socket, head, user);
-  }
+  await handleUpgrade(request, socket, head);
 });
 
 server.listen(settings.PORT, settings.HOST, () => {

--- a/backend/src/services/auth.ts
+++ b/backend/src/services/auth.ts
@@ -1,6 +1,5 @@
 import { Request, Response } from 'express';
 import { IncomingMessage } from 'http';
-import internal from 'stream';
 
 import { getUsers } from '../auth/cognito';
 import { User } from '../auth/user';
@@ -17,31 +16,29 @@ async function fetchUserDetails(accessToken: string) {
   });
 }
 
-export async function getUserDetailsForWs(req: IncomingMessage, socket: internal.Duplex) {
+export async function getUserDetailsForWs(req: IncomingMessage): Promise<User> {
   if (settings.NODE_ENV === 'development') {
     return new User('local.user', 'local.user@example.com');
   }
 
-  const accessToken = req.headers['X-Auth-Request-Access-Token'][0];
+  const accessToken = req.headers['X-Auth-Request-Access-Token']?.at(0);
 
   if (!accessToken) {
-    socket.destroy();
     throw new ApplicationError('Error: invalid response recieved when getting user details.');
   }
 
   const response = await fetchUserDetails(accessToken);
 
   if (!response.ok) {
-    socket.destroy();
     throw new ApplicationError(
       `Error: ${response.status}(${response.statusText}) recieved when fetching sign out links.`
     );
   }
 
-  return response.json();
+  return response.json().then((value) => new User(value.content.username, value.content.email));
 }
 
-export async function getUserDetails(req: Request) {
+export async function getUserDetails(req: Request): Promise<User> {
   if (settings.NODE_ENV === 'development') {
     return new User('local.user', 'local.user@example.com');
   }
@@ -58,7 +55,7 @@ export async function getUserDetails(req: Request) {
     throw new ApplicationError('Error: invalid response recieved when getting user details.');
   }
 
-  return response.json();
+  return response.json().then((value) => new User(value.content.username, value.content.email));
 }
 
 export async function user(_req: Request, res: Response) {
@@ -77,9 +74,10 @@ export async function logout(_req: Request, res: Response) {
   }
 
   try {
-    const response = await fetch(`${settings.IDENTITY_API_URL}/api/v1/links/sign-out`, {
-      method: 'GET'
-    });
+    const response = await fetch(`${settings.IDENTITY_API_URL}/oauth2/sign_out`, {
+      method: 'GET',
+      redirect: 'manual'
+    }).then(() => fetch(`${settings.IDENTITY_API_URL}/api/v1/links/sign-out`, { method: 'GET' }));
 
     if (!response.ok) {
       throw new ApplicationError(


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The websocket integration was failing because it did not have access to the proper request header to authenticate the user in the backend. The sign out functionality was not working e2e on the deployed demo environment because the user wasnt actually being signed just being redirected.

## Description
<!--- Describe your changes in detail -->
- Shifted the call to authenticate the user upon connection rather than upgrade request.
- Added an extra call to sign the user out and then redirect them to restart their oauth journey.
- Made socket connection more resilient by closing the socket (this ensures so it retries this) and logging the error on failure.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested locally and shown to be working.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.