### PR TITLE
fix(dpav-555): passed the username for ws, handled sign out properly

### DIFF
--- a/backend/src/pubSub/server.ts
+++ b/backend/src/pubSub/server.ts
@@ -5,7 +5,6 @@ import { WebSocket, WebSocketServer } from 'ws';
 import { User } from '../auth/user';
 import Broker from './broker';
 import PubSubManager from './manager';
-import { getUserDetailsForWs } from '../services/auth';
 
 const wss = new WebSocketServer({ noServer: true });
 const broker = new Broker();
@@ -14,10 +13,11 @@ wss.on('connection', async (ws: WebSocket, request: IncomingMessage) => {
   let user: User;
 
   try {
-    user = await getUserDetailsForWs(request);
+    const username = request.headers['sec-websocket-protocol'].split(',')[1].trim();
+    user = new User(username, '');
   } catch (error) {
-    console.log(`Error upon connecting websocket: ${error}`);
     ws.close();
+    console.log(error);
     return;
   }
 

--- a/backend/src/services/auth.ts
+++ b/backend/src/services/auth.ts
@@ -1,5 +1,4 @@
 import { Request, Response } from 'express';
-import { IncomingMessage } from 'http';
 
 import { getUsers } from '../auth/cognito';
 import { User } from '../auth/user';
@@ -14,28 +13,6 @@ async function fetchUserDetails(accessToken: string) {
     },
     credentials: 'include'
   });
-}
-
-export async function getUserDetailsForWs(req: IncomingMessage): Promise<User> {
-  if (settings.NODE_ENV === 'development') {
-    return new User('local.user', 'local.user@example.com');
-  }
-
-  const accessToken = req.headers['X-Auth-Request-Access-Token']?.at(0);
-
-  if (!accessToken) {
-    throw new ApplicationError('Error: invalid response recieved when getting user details.');
-  }
-
-  const response = await fetchUserDetails(accessToken);
-
-  if (!response.ok) {
-    throw new ApplicationError(
-      `Error: ${response.status}(${response.statusText}) recieved when fetching sign out links.`
-    );
-  }
-
-  return response.json().then((value) => new User(value.content.username, value.content.email));
 }
 
 export async function getUserDetails(req: Request): Promise<User> {
@@ -74,7 +51,7 @@ export async function logout(_req: Request, res: Response) {
   }
 
   try {
-    const response = await fetch(`${settings.IDENTITY_API_URL}/oauth2/sign_out`, {
+    const response = await fetch(`${settings.LANDING_PAGE_URL}/oauth2/sign_out`, {
       method: 'GET',
       redirect: 'manual'
     }).then(() => fetch(`${settings.IDENTITY_API_URL}/api/v1/links/sign-out`, { method: 'GET' }));

--- a/frontend/src/api/ws.ts
+++ b/frontend/src/api/ws.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line import/no-relative-packages
+import { User } from '../../../common/User';
+
 export class WebSocketClient {
   private ws: WebSocket | undefined;
 
@@ -11,9 +14,12 @@ export class WebSocketClient {
 
   private readonly connectionCallback: () => void | undefined;
 
-  constructor(connectionCallback: () => void, messageCallback: (msg: string) => void) {
+  private readonly user: User;
+
+  constructor(connectionCallback: () => void, messageCallback: (msg: string) => void, user: User) {
     this.connectionCallback = connectionCallback;
     this.messageCallback = messageCallback;
+    this.user = user;
     this.connect();
   }
 
@@ -31,7 +37,7 @@ export class WebSocketClient {
 
   private connect(isRestoration: boolean = false) {
     const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
-    const ws = new WebSocket(`${protocol}://${window.location.host}/api/ws`);
+    const ws = new WebSocket(`${protocol}://${window.location.host}/api/ws`, [protocol, this.user.username]);
     ws.onopen = () => {
       this.handleOpen(isRestoration);
     };

--- a/frontend/src/providers/AuthContextProvider.tsx
+++ b/frontend/src/providers/AuthContextProvider.tsx
@@ -14,11 +14,17 @@ const AuthContextProvider = ({ children }: PropsWithChildren) => {
   });
 
   const logout = async () => {
-    await fetch('/api/auth/logout').then(async (response) => {
-      const signOutUrl = await response.json();
-
-      document.location = signOutUrl;
-    });
+    await fetch('/api/auth/logout').then(
+      async (response) => {
+        if (response.ok) {
+          const signOutUrl = await response.json();
+          document.location = signOutUrl;
+        } else {
+          document.location = '/';
+        }
+      },
+      () => { document.location = '/'; }
+    );
   };
 
   useEffect(() => {

--- a/frontend/src/providers/MessagingProvider.tsx
+++ b/frontend/src/providers/MessagingProvider.tsx
@@ -25,7 +25,7 @@ export default function MessagingProvider({ children }: Readonly<PropsWithChildr
     if (!user.current) {
       return undefined;
     }
-    ws.current = new WebSocketClient(handleConnection, handleIncoming);
+    ws.current = new WebSocketClient(handleConnection, handleIncoming, user.current);
     return () => {
       ws.current?.close();
       ws.current = null;


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The X-Auth-Request-Access-Token header was still not being passed along with the WS request. The sign out process did not have the correct URL and proper error handling on the frontend.

## Description
<!--- Describe your changes in detail -->
- Added the correct URL for the signout journey
- Added error handling to the frontend for sign out
- Passed the username in the predefined headers for web socket connections

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested e2e flow with both the landing page API and frontend up and it is working.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.