### PR TITLE
fix(dpav-555): return oauth signout link with signout links

### DIFF
--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -33,7 +33,6 @@ router.use(express.static(`${baseDir}/frontend`));
 const apiRouter = Router();
 router.use('/api', apiRouter);
 
-apiRouter.get('/auth/logout', auth.logout);
 apiRouter.get('/auth/logout-links', auth.logoutLinks);
 
 apiRouter.use(authenticate());

--- a/backend/src/services/auth.ts
+++ b/backend/src/services/auth.ts
@@ -45,35 +45,13 @@ export async function user(_req: Request, res: Response) {
   res.json({ username: user.username, displayName: user.displayName });
 }
 
-export async function logout(_req: Request, res: Response) {
-  if (settings.NODE_ENV === 'development') {
-    return res.json('/');
-  }
-
-  try {
-    const response = await fetch(`${settings.LANDING_PAGE_URL}/oauth2/sign-out`, {
-      method: 'GET',
-      redirect: 'manual'
-    });
-
-    if (!response.ok) {
-      throw new ApplicationError(
-        `Error: ${response.status}(${response.statusText}) recieved when fetching sign out links.`
-      );
-    }
-
-    return response;
-  } catch (error) {
-    throw new ApplicationError(error);
-  }
-}
-
 export async function logoutLinks(_req: Request, res: Response) {
   if (settings.NODE_ENV === 'development') {
-    return res.json('/');
+    return res.json({ oAuthLogoutUrl: '/', redirect: '/' });
   }
 
   try {
+    const oAuthLogoutUrl = `${settings.LANDING_PAGE_URL}/oauth2/sign-out`;
     const response = await fetch(`${settings.IDENTITY_API_URL}/api/v1/links/sign-out`, { method: 'GET' });
 
     if (!response.ok) {
@@ -82,8 +60,8 @@ export async function logoutLinks(_req: Request, res: Response) {
       );
     }
 
-    const signoutURL = await response.json();
-    return res.json(signoutURL.href);
+    const logoutRedirect = await response.json();
+    return res.json({ oAuthLogoutUrl, redirect: logoutRedirect.href });
   } catch (error) {
     throw new ApplicationError(error);
   }

--- a/frontend/qa/src/hooks/hooks.ts
+++ b/frontend/qa/src/hooks/hooks.ts
@@ -50,6 +50,7 @@ After(async function TestCaseHook({ pickle, result }) {
     if (video) {
       videoPath = await video.path();
     } else {
+      // eslint-disable-next-line no-console
       console.warn('No video recorded for this test.');
     }
   }
@@ -68,18 +69,17 @@ After(async function TestCaseHook({ pickle, result }) {
       const videoData = fs.readFileSync(videoPath);
       this.attach(videoData, 'video/webm');
     } else {
+      // eslint-disable-next-line no-console
       console.warn('Video file not found or not recorded.');
     }
 
     // Attach the trace file
     if (fs.existsSync(path)) {
-      // console.log('File exists.');
       const traceFileLink = `<a href="https://trace.playwright.dev/">Open ${path}</a>`;
       this.attach(`Trace file: ${traceFileLink}`, 'text/html');
     } else {
       // eslint-disable-next-line no-console
       console.log('File does not exist.');
-      // console.warn('Trace file not found.');
     }
   }
 });

--- a/frontend/src/providers/AuthContextProvider.tsx
+++ b/frontend/src/providers/AuthContextProvider.tsx
@@ -14,20 +14,16 @@ const AuthContextProvider = ({ children }: PropsWithChildren) => {
   });
 
   const logout = async () => {
-    await fetch('/api/auth/logout').then(
-      () => fetch('/api/auth/logout-links').then(
-        async (response) => {
-          if (response.ok) {
-            const signOutUrl = await response.json();
-            document.location = signOutUrl;
-          } else {
-            document.location = '/';
-          }
-        },
-        () => {
+    await fetch('/api/auth/logout-links').then(
+      async (response) => {
+        if (response.ok) {
+          const logoutLinks = await response.json();
+          await fetch(logoutLinks.oAuthLogoutUrl, { method: 'GET', redirect: 'manual' });
+          document.location = logoutLinks.redirect;
+        } else {
           document.location = '/';
         }
-      ),
+      },
       () => {
         document.location = '/';
       }


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The oauth call was being made in the backend to clear the OIDC cookie which was not being reflected in the frontend as this is only something the frontent has to do actively.

## Description
<!--- Describe your changes in detail -->
- Moved the call to the oauth endpoint to the front end and return the oauth url and the general sign out links under a single call to the API.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Fallbacks are working as expected but the real test will be in the demo environment.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.