### PR TITLE
fix(non-req): remove incident id from the home page

### DIFF
--- a/frontend/src/components/Map/config.ts
+++ b/frontend/src/components/Map/config.ts
@@ -1,21 +1,22 @@
 import { LngLatBoundsLike, StyleSpecification } from 'maplibre-gl';
 import { ViewState } from 'react-map-gl/dist/esm/types';
 
-const apiKey = '<insert os api key here>';
 export const MAP_STYLE: StyleSpecification = {
   version: 8,
   sources: {
     'raster-tiles': {
       type: 'raster',
-      tiles: [`https://api.os.uk/maps/raster/v1/zxy/Outdoor_3857/{z}/{x}/{y}.png?key=${apiKey}`],
+      tiles: ['/transparent-proxy/maps/raster/v1/zxy/Outdoor_3857/{z}/{x}/{y}.png?'],
       tileSize: 256
     }
   },
-  layers: [{
-    id: 'os-maps-zxy',
-    type: 'raster',
-    source: 'raster-tiles'
-  }]
+  layers: [
+    {
+      id: 'os-maps-zxy',
+      type: 'raster',
+      source: 'raster-tiles'
+    }
+  ]
 };
 
 // UK bounds, with a bit of padding.

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -57,9 +57,7 @@ const Home = () => {
 
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
-  const tableHeaders = isMobile
-    ? ['ID', 'Incident']
-    : ['Incident ID', 'Incident name', 'Reported by', 'Date', 'Stage'];
+  const tableHeaders = isMobile ? ['Incident'] : ['Incident name', 'Reported by', 'Date', 'Stage'];
 
   return (
     <PageWrapper>
@@ -125,7 +123,6 @@ const Home = () => {
               const { id, name, reportedBy, startedAt } = incident;
               return isMobile ? (
                 <TableRow key={id}>
-                  <TableCell>{id}</TableCell>
                   <TableCell width="70%">
                     <Box display="flex" flexDirection="column" gap="0.3rem">
                       <Typography
@@ -151,7 +148,6 @@ const Home = () => {
                 </TableRow>
               ) : (
                 <TableRow key={id}>
-                  <TableCell>{id}</TableCell>
                   <TableCell>
                     <Typography
                       component={Link}


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The incident id is not meant to be displayed on the home page. The os api integration is still relying on contacting the os api directly from the app.

## Description
<!--- Describe your changes in detail -->
- Removed the incident id column from the home page
- Changed the os api url to call the transparent proxy

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested locally and is working

## Screenshots (if appropriate):
![lisa-homepage](https://github.com/user-attachments/assets/be253beb-74bd-417c-9f09-b0dab80387aa)
![lisa-homepage-mobile](https://github.com/user-attachments/assets/b58303de-6355-4bd1-9b71-4423be85f69a)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.