### PR TITLE
fix(non-req): added ability to get ws host from self location host

### DIFF
--- a/frontend/src/api/ws.ts
+++ b/frontend/src/api/ws.ts
@@ -37,7 +37,9 @@ export class WebSocketClient {
 
   private connect(isRestoration: boolean = false) {
     const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
-    const ws = new WebSocket(`${protocol}://${import.meta.env.VITE_BACKEND_HOST}/api/ws`, [protocol, this.user.username]);
+    /* eslint-disable-next-line no-restricted-globals */
+    const backendHost = import.meta.env.VITE_BACKEND_HOST || self.window.location.host;
+    const ws = new WebSocket(`${protocol}://${backendHost}/api/ws`, [protocol, this.user.username]);
     ws.onopen = () => {
       this.handleOpen(isRestoration);
     };


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The hostname for the web socket connection was being pulled from an env variable. This is more for local development and causes the ws request to not complete successfully.

## Description
<!--- Describe your changes in detail -->
- Added a null coalesce when getting the host name for the ws request which default to fetching it from the location host.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Can only be tested in deployed due to local config

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.