### PR TITLE
fix(dpav-575): shifted log sequence generation to client.

### DIFF
--- a/backend/src/services/logEntry/create.ts
+++ b/backend/src/services/logEntry/create.ts
@@ -27,20 +27,9 @@ export async function create(req: Request, res: Response) {
     entry.dateTime = now.toISOString();
   }
 
-  const sequenceNumberElements = [
-    now.getDate(),
-    now.getMonth() + 1, // to account for zero based indexing on the month
-    now.getHours(),
-    now.getMinutes(),
-    now.getSeconds()
-  ];
-
   const entryId = randomUUID();
   entry.id = entryId;
 
-  const entrySequenceNumber = sequenceNumberElements
-    .map((element) => String(element).padStart(2, '0'))
-    .join('');
   const entryIdNode = ns.data(entryId);
   const incidentIdNode = ns.data(incidentId);
   const authorNode = ns.data(res.locals.user.username);
@@ -69,7 +58,7 @@ export async function create(req: Request, res: Response) {
       [authorNode, ns.rdf.type, ns.ies.Creator],
       [authorNode, ns.ies.hasName, literalString(res.locals.user.displayName)],
       [authorNode, ns.ies.isParticipantIn, entryIdNode],
-      [entryIdNode, ns.lisa.hasSequence, entrySequenceNumber],
+      [entryIdNode, ns.lisa.hasSequence, entry.sequence],
 
       ...fields.extract(entry, entryIdNode),
       ...mentions.extract.logEntry(entry, entryIdNode),

--- a/frontend/src/components/AddEntry/index.tsx
+++ b/frontend/src/components/AddEntry/index.tsx
@@ -38,6 +38,17 @@ type AddEntryProps = {
   loading?: boolean;
 };
 
+const createSequenceNumber = (date: Date) =>
+  [
+    date.getDate(),
+    date.getMonth() + 1, // to account for zero based indexing on the month
+    date.getHours(),
+    date.getMinutes(),
+    date.getSeconds()
+  ]
+    .map((element) => String(element).padStart(2, '0'))
+    .join('');
+
 const AddEntry = ({
   incident = undefined,
   entries,
@@ -50,6 +61,7 @@ const AddEntry = ({
   const { users } = useUsers();
   const [entry, setEntry] = useState<Partial<LogEntry>>({
     incidentId: incident?.id,
+    sequence: createSequenceNumber(new Date()),
     type: 'General',
     content: {}
   });


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The log id generation was in the backend right before inserting the log entry. This was causing the duplicate ids issues to crop up again.

## Description
<!--- Describe your changes in detail -->
- Shifted the generation of the log id to the client as a default value.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested locally and is working e2e and mocked offline mode using tanstack dev tools.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.