### PR TITLE
[NON-REQ] Log Entry - Notification relationship is not optional

### DIFF
--- a/backend/src/services/notifications/index.ts
+++ b/backend/src/services/notifications/index.ts
@@ -61,6 +61,10 @@ export async function get(req: Request, res: Response) {
       ['?id', ns.rdf.type, '?type'],
       ['?id', ns.lisa.hasRecipient, '?recipient'],
       ['?id', ns.lisa.createdAt, '?createdAt'],
+      ['?id', ns.lisa.hasLogEntry, '?entryId'],
+      ['?id', ns.lisa.hasIncident, '?incidentId'],
+      ['?entryId', ns.ies.inPeriod, '?dateTime'],
+      ['?entryId', ns.lisa.hasSequence, '?sequence'],
       sparql.optional([
         ['?id', ns.lisa.readAt, '?read']
       ]),

--- a/backend/src/services/notifications/utils.ts
+++ b/backend/src/services/notifications/utils.ts
@@ -24,10 +24,6 @@ export function getFetchOptionals(): unknown[] {
   return [
     // user mention
     sparql.optional([
-      ['?id', ns.lisa.hasLogEntry, '?entryId'],
-      ['?id', ns.lisa.hasIncident, '?incidentId'],
-      ['?entryId', ns.ies.inPeriod, '?dateTime'],
-      ['?entryId', ns.lisa.hasSequence, '?sequence'],
       ['?entryId', ns.lisa.contentText, '?contentText'],
       ['?author', ns.ies.isParticipantIn, '?entryId'],
       ['?author', ns.ies.hasName, '?authorName']


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
Notifications fetch is erroring in DEV

## Description
Bad data in dev means a notification has been saved without a reference to a Log Entry, since the code after the fetch depends on this being present and the only type of notification that exists is explicitly tied to a log entry, moved this link fetch out of the optional block and into the mandatory block. This orphaned notification will now be ignored by the fetch.

## How Has This Been Tested?
Tested that things still work locally, needs deploying to verify DEV-specific surfacing of issue.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.