### PR TITLE
feat([DPAV-765]) Parameterise deployment resources per tenant

### DIFF
--- a/deployment/k8s/backend/base/deployment.yaml
+++ b/deployment/k8s/backend/base/deployment.yaml
@@ -4,25 +4,25 @@ metadata:
   annotations:
     reloader.stakater.com/auto: "true"
 
-  name: lisa-backend
+  name: $(TENANT)-backend
 spec:
   replicas: 1
   selector:
     matchLabels:
-      io.kompose.service: lisa-backend
+      io.kompose.service: $(TENANT)-backend
   template:
     metadata:
       annotations: {}
       labels:
-        io.kompose.service: lisa-backend
+        io.kompose.service: $(TENANT)-backend
     spec:
-      serviceAccountName: lisa-backend-sa
+      serviceAccountName: $(TENANT)-backend-sa
       containers:
         - envFrom:
                - configMapRef:
-                   name: lisa-backend-configs
+                   name: $(TENANT)-backend-configs
                - secretRef:
-                   name: lisa-backend-secrets
+                   name: $(TENANT)-backend-secrets
           livenessProbe:
             httpGet:
               path: /api
@@ -37,7 +37,7 @@ spec:
               failureThreshold: 5
               periodSeconds: 30
               timeoutSeconds: 20
-          name: lisa
+          name: $(TENANT)
           image: lisa-backend-image:template
           resources:
             limits:

--- a/deployment/k8s/backend/base/istio/allow-ingress-authorization-policy.yaml
+++ b/deployment/k8s/backend/base/istio/allow-ingress-authorization-policy.yaml
@@ -2,11 +2,11 @@
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
-  name: allow-ingress-to-lisa-backend
+  name: allow-ingress-to-$(TENANT)-backend
 spec:
   selector:
     matchLabels:
-      io.kompose.service: lisa-backend
+      io.kompose.service: $(TENANT)-backend
   action: ALLOW
   rules:
     - from:

--- a/deployment/k8s/backend/base/kustomization.yaml
+++ b/deployment/k8s/backend/base/kustomization.yaml
@@ -9,8 +9,8 @@ resources:
 
 labels:
   - pairs:
-      app: lisa-backend
+      app: $(TENANT)-backend
       env: ENV_PLACEHOLDER
-      app.kubernetes.io/name: lisa-backend
+      app.kubernetes.io/name: $(TENANT)-backend
 
 

--- a/deployment/k8s/backend/base/service-account.yaml
+++ b/deployment/k8s/backend/base/service-account.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: lisa-backend-sa
+  name: $(TENANT)-backend-sa
   annotations:
     eks.amazonaws.com/role-arn: placeholder
 automountServiceAccountToken: false

--- a/deployment/k8s/backend/base/service.yaml
+++ b/deployment/k8s/backend/base/service.yaml
@@ -4,8 +4,8 @@ metadata:
   annotations: {}
 
   labels:
-    io.kompose.service: lisa-backend
-  name: lisa-backend
+    io.kompose.service: $(TENANT)-backend
+  name: $(TENANT)-backend
 spec:
   type: NodePort
   ports:
@@ -13,4 +13,4 @@ spec:
       port: 80
       targetPort: 3000
   selector:
-    io.kompose.service: lisa-backend
+    io.kompose.service: $(TENANT)-backend

--- a/deployment/k8s/backend/base/vault/vaultAuth.yaml
+++ b/deployment/k8s/backend/base/vault/vaultAuth.yaml
@@ -1,12 +1,12 @@
 apiVersion: secrets.hashicorp.com/v1beta1
 kind: VaultAuth
 metadata:
-  name: lisa-backend-vault-auth
+  name: $(TENANT)-backend-vault-auth
 spec:
   method: kubernetes
   mount: kubernetes
   kubernetes:
-    role: lisa-backend-role
-    serviceAccount: lisa-backend-sa
+    role: $(TENANT)-backend-role
+    serviceAccount: $(TENANT)-backend-sa
     audiences:
       - vault

--- a/deployment/k8s/backend/base/vault/vaultStaticSecret.yaml
+++ b/deployment/k8s/backend/base/vault/vaultStaticSecret.yaml
@@ -1,7 +1,7 @@
 apiVersion: secrets.hashicorp.com/v1beta1
 kind: VaultStaticSecret
 metadata:
-  name: lisa-backend-static-secret
+  name: $(TENANT)-backend-static-secret
 spec:
   refreshAfter: 30s
   # path of the secret
@@ -10,6 +10,6 @@ spec:
   mount: k8-cluster
   destination:
     # destination k8s secret
-    name: lisa-backend-secrets
+    name: $(TENANT)-backend-secrets
     create: true
-  vaultAuthRef: lisa-backend-vault-auth
+  vaultAuthRef: $(TENANT)-backend-vault-auth

--- a/deployment/k8s/backend/overlays/dev/lisa-t1/kustomization.yaml
+++ b/deployment/k8s/backend/overlays/dev/lisa-t1/kustomization.yaml
@@ -2,11 +2,11 @@ resources:
   - ../../../base
   - namespace.yaml
 
-namespace: lisa
+namespace: $(TENANT)
 
 
 configMapGenerator:
-  - name: lisa-backend-configs
+  - name: $(TENANT)-backend-configs
     envs:
       - params.env
 
@@ -14,7 +14,7 @@ patches:
   - path: patches/service-account.yaml
     target:
       kind: ServiceAccount
-      name: lisa-backend-sa
+      name: $(TENANT)-backend-sa
   - path: patches/allow-ingress.yaml
     target:
       kind: AuthorizationPolicy
@@ -28,4 +28,10 @@ images:
     newName: 503561419905.dkr.ecr.eu-west-2.amazonaws.com/lisa/api
     newTag: '1739959086'
 
+vars:
+  - name: TENANT
+    objref:
+      kind: Namespace
+      name: lisa
+      apiVersion: v1
 

--- a/deployment/k8s/backend/overlays/dev/lisa-t1/patches/allow-ingress.yaml
+++ b/deployment/k8s/backend/overlays/dev/lisa-t1/patches/allow-ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
-  name: allow-ingress-to-lisa-backend
+  name: allow-ingress-to-$(TENANT)-backend
 spec:
   rules:
     - from:

--- a/deployment/k8s/backend/overlays/dev/lisa-t2/kustomization.yaml
+++ b/deployment/k8s/backend/overlays/dev/lisa-t2/kustomization.yaml
@@ -2,11 +2,11 @@ resources:
   - ../../../base
   - namespace.yaml
 
-namespace: lisa-t2
+namespace: $(TENANT)
 
 
 configMapGenerator:
-  - name: lisa-backend-configs
+  - name: $(TENANT)-backend-configs
     envs:
       - params.env
 
@@ -14,7 +14,7 @@ patches:
   - path: patches/service-account.yaml
     target:
       kind: ServiceAccount
-      name: lisa-backend-sa
+      name: $(TENANT)-backend-sa
   - path: patches/allow-ingress.yaml
     target:
       kind: AuthorizationPolicy
@@ -28,4 +28,10 @@ images:
     newName: 503561419905.dkr.ecr.eu-west-2.amazonaws.com/lisa/api
     newTag: '1739959086'
 
+vars:
+  - name: TENANT
+    objref:
+      kind: Namespace
+      name: lisa-t2
+      apiVersion: v1
 

--- a/deployment/k8s/backend/overlays/dev/lisa-t2/patches/allow-ingress.yaml
+++ b/deployment/k8s/backend/overlays/dev/lisa-t2/patches/allow-ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
-  name: allow-ingress-to-lisa-backend
+  name: allow-ingress-to-$(TENANT)-backend
 spec:
   rules:
     - from:

--- a/deployment/k8s/base/deployment.yaml
+++ b/deployment/k8s/base/deployment.yaml
@@ -2,25 +2,25 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations: {}
-  name: lisa-webapp
+  name: $(TENANT)-webapp
 spec:
   replicas: 1
   selector:
     matchLabels:
-      io.kompose.service: lisa
+      io.kompose.service: $(TENANT)
   template:
     metadata:
       annotations: {}
       labels:
-        io.kompose.service: lisa
+        io.kompose.service: $(TENANT)
     spec:
-      serviceAccountName: lisa-sa
+      serviceAccountName: $(TENANT)-sa
       containers:
         - envFrom:
                - configMapRef:
-                   name: lisa-configs
+                   name: $(TENANT)-configs
                - secretRef:
-                   name: lisa-secrets
+                   name: $(TENANT)-secrets
           livenessProbe:
            httpGet:
              port: 3000
@@ -35,7 +35,7 @@ spec:
             failureThreshold: 5
             periodSeconds: 30
             timeoutSeconds: 20
-          name: lisa
+          name: $(TENANT)
           image: lisa-image:template
           resources:
             limits:

--- a/deployment/k8s/base/istio/gateway.yaml
+++ b/deployment/k8s/base/istio/gateway.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
-  name: lisa-ingress-gateway
+  name: $(TENANT)-ingress-gateway
 spec:
   selector:
     app: istio-ingress

--- a/deployment/k8s/base/istio/virtualService.yaml
+++ b/deployment/k8s/base/istio/virtualService.yaml
@@ -21,7 +21,7 @@ spec:
   hosts:
     - lisa.staging.ndtp.co.uk
   gateways:
-    - lisa/lisa-ingress-gateway
+    - $(TENANT)/$(TENANT)-ingress-gateway
   http:
     - match:
         - uri:
@@ -33,6 +33,6 @@ spec:
           rewrite: /\2
       route:
         - destination:
-            host: lisa
+            host: $(TENANT)
             port:
               number: 80

--- a/deployment/k8s/base/kustomization.yaml
+++ b/deployment/k8s/base/kustomization.yaml
@@ -9,8 +9,8 @@ resources:
 
 labels:
   - pairs:
-      app: lisa
+      app: $(TENANT)
       env: ENV_PLACEHOLDER
-      app.kubernetes.io/name: lisa
+      app.kubernetes.io/name: $(TENANT)
 
 

--- a/deployment/k8s/base/service-account.yaml
+++ b/deployment/k8s/base/service-account.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: lisa-sa
+  name: $(TENANT)-sa
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::503561419905:role/lisa-access-role
 automountServiceAccountToken: false

--- a/deployment/k8s/base/service.yaml
+++ b/deployment/k8s/base/service.yaml
@@ -9,8 +9,8 @@ metadata:
 #    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "https"
 
   labels:
-    io.kompose.service: lisa-webapp
-  name: lisa
+    io.kompose.service: $(TENANT)-webapp
+  name: $(TENANT)
 spec:
   type: ClusterIP
   ports:
@@ -18,4 +18,4 @@ spec:
       port: 80
       targetPort: 3000
   selector:
-    io.kompose.service: lisa
+    io.kompose.service: $(TENANT)

--- a/deployment/k8s/transparent-proxy/base/deployment.yaml
+++ b/deployment/k8s/transparent-proxy/base/deployment.yaml
@@ -8,20 +8,20 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      io.kompose.service: lisa-transparent-proxy
+      io.kompose.service: $(TENANT)-transparent-proxy
   template:
     metadata:
       annotations: {}
       labels:
-        io.kompose.service: lisa-transparent-proxy
+        io.kompose.service: $(TENANT)-transparent-proxy
     spec:
-      serviceAccountName: lisa-transparent-proxy-sa
+      serviceAccountName: $(TENANT)-transparent-proxy-sa
       containers:
         - envFrom:
                - configMapRef:
-                   name: lisa-transparent-proxy-configs
+                   name: $(TENANT)-transparent-proxy-configs
                - secretRef:
-                   name: lisa-transparent-proxy-secrets
+                   name: $(TENANT)-transparent-proxy-secrets
           livenessProbe:
             httpGet:
               path: /transparent-proxy/health
@@ -29,7 +29,7 @@ spec:
             failureThreshold: 5
             periodSeconds: 30
             timeoutSeconds: 10
-          name: lisa-transparent-proxy
+          name: $(TENANT)-transparent-proxy
           image: lisa-transparent-proxy-image:template
           resources:
             limits:

--- a/deployment/k8s/transparent-proxy/base/istio/authorizationpolicy/allow-ingress-to-lisa-transparent-proxy.yaml
+++ b/deployment/k8s/transparent-proxy/base/istio/authorizationpolicy/allow-ingress-to-lisa-transparent-proxy.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      io.kompose.service: lisa-transparent-proxy
+      io.kompose.service: $(TENANT)-transparent-proxy
   action: ALLOW
   rules:
     - from:

--- a/deployment/k8s/transparent-proxy/base/kustomization.yaml
+++ b/deployment/k8s/transparent-proxy/base/kustomization.yaml
@@ -10,6 +10,6 @@ resources:
 
 labels:
   - pairs:
-      app: lisa-transparent-proxy
+      app: $(TENANT)-transparent-proxy
       env: ENV_PLACEHOLDER
-      app.kubernetes.io/name: lisa-transparent-proxy
+      app.kubernetes.io/name: $(TENANT)-transparent-proxy

--- a/deployment/k8s/transparent-proxy/base/service-account.yaml
+++ b/deployment/k8s/transparent-proxy/base/service-account.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: lisa-transparent-proxy-sa
+  name: $(TENANT)-transparent-proxy-sa
   annotations:
     eks.amazonaws.com/role-arn: placeholder
 automountServiceAccountToken: false

--- a/deployment/k8s/transparent-proxy/base/service.yaml
+++ b/deployment/k8s/transparent-proxy/base/service.yaml
@@ -3,8 +3,8 @@ kind: Service
 metadata:
   annotations: {}
   labels:
-    io.kompose.service: lisa-transparent-proxy
-  name: lisa-transparent-proxy
+    io.kompose.service: $(TENANT)-transparent-proxy
+  name: $(TENANT)-transparent-proxy
 spec:
   type: ClusterIP
   ports:
@@ -12,4 +12,4 @@ spec:
       port: 80
       targetPort: 80
   selector:
-    io.kompose.service: lisa-transparent-proxy
+    io.kompose.service: $(TENANT)-transparent-proxy

--- a/deployment/k8s/transparent-proxy/base/vault/vaultAuth.yaml
+++ b/deployment/k8s/transparent-proxy/base/vault/vaultAuth.yaml
@@ -1,12 +1,12 @@
 apiVersion: secrets.hashicorp.com/v1beta1
 kind: VaultAuth
 metadata:
-  name: lisa-transparent-proxy-vault-auth
+  name: $(TENANT)-transparent-proxy-vault-auth
 spec:
   method: kubernetes
   mount: kubernetes
   kubernetes:
-    role: lisa-transparent-proxy-role
-    serviceAccount: lisa-transparent-proxy-sa
+    role: $(TENANT)-transparent-proxy-role
+    serviceAccount: $(TENANT)-transparent-proxy-sa
     audiences:
       - vault

--- a/deployment/k8s/transparent-proxy/base/vault/vaultStaticSecret.yaml
+++ b/deployment/k8s/transparent-proxy/base/vault/vaultStaticSecret.yaml
@@ -1,7 +1,7 @@
 apiVersion: secrets.hashicorp.com/v1beta1
 kind: VaultStaticSecret
 metadata:
-  name: lisa-transparent-proxy-static-secret
+  name: $(TENANT)-transparent-proxy-static-secret
 spec:
   refreshAfter: 30s
   # path of the secret
@@ -10,6 +10,6 @@ spec:
   mount: k8-cluster
   destination:
     # destination k8s secret
-    name: lisa-transparent-proxy-secrets
+    name: $(TENANT)-transparent-proxy-secrets
     create: true
-  vaultAuthRef: lisa-transparent-proxy-vault-auth
+  vaultAuthRef: $(TENANT)-transparent-proxy-vault-auth

--- a/deployment/k8s/transparent-proxy/overlays/dev/lisa-t1/kustomization.yaml
+++ b/deployment/k8s/transparent-proxy/overlays/dev/lisa-t1/kustomization.yaml
@@ -2,10 +2,10 @@ resources:
   - ../../../base
   - namespace.yaml
 
-namespace: lisa
+namespace: $(TENANT)
 
 configMapGenerator:
-  - name: lisa-transparent-proxy-configs
+  - name: $(TENANT)-transparent-proxy-configs
     envs:
       - params.env
 
@@ -25,3 +25,9 @@ images:
     newTag: "1736292556"
 
 
+vars:
+  - name: TENANT
+    objref:
+      kind: Namespace
+      name: lisa
+      apiVersion: v1

--- a/deployment/k8s/transparent-proxy/overlays/dev/lisa-t2/kustomization.yaml
+++ b/deployment/k8s/transparent-proxy/overlays/dev/lisa-t2/kustomization.yaml
@@ -2,10 +2,10 @@ resources:
   - ../../../base
   - namespace.yaml
 
-namespace: lisa-t2
+namespace: $(TENANT)
 
 configMapGenerator:
-  - name: lisa-transparent-proxy-configs
+  - name: $(TENANT)-transparent-proxy-configs
     envs:
       - params.env
 
@@ -25,3 +25,9 @@ images:
     newTag: "1736292556"
 
 
+vars:
+  - name: TENANT
+    objref:
+      kind: Namespace
+      name: lisa-t2
+      apiVersion: v1

--- a/deployment/k8s/webapp/base/deployment.yaml
+++ b/deployment/k8s/webapp/base/deployment.yaml
@@ -2,19 +2,19 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations: {}
-  name: lisa-webapp
+  name: $(TENANT)-webapp
 spec:
   replicas: 1
   selector:
     matchLabels:
-      io.kompose.service: lisa
+      io.kompose.service: $(TENANT)
   template:
     metadata:
       annotations: {}
       labels:
-        io.kompose.service: lisa
+        io.kompose.service: $(TENANT)
     spec:
-      serviceAccountName: lisa-sa
+      serviceAccountName: $(TENANT)-sa
       containers:
         - image: lisa-image:template
           livenessProbe:
@@ -31,7 +31,7 @@ spec:
               failureThreshold: 5
               periodSeconds: 30
               timeoutSeconds: 20
-          name: lisa
+          name: $(TENANT)
           resources:
             limits:
               memory: "2Gi"

--- a/deployment/k8s/webapp/base/istio/allow-ingress-authorization-policy.yaml
+++ b/deployment/k8s/webapp/base/istio/allow-ingress-authorization-policy.yaml
@@ -2,11 +2,11 @@
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
-  name: allow-ingress-to-lisa-webapp
+  name: allow-ingress-to-$(TENANT)-webapp
 spec:
   selector:
     matchLabels:
-      io.kompose.service: lisa
+      io.kompose.service: $(TENANT)
   action: ALLOW
   rules:
     - from:

--- a/deployment/k8s/webapp/base/kustomization.yaml
+++ b/deployment/k8s/webapp/base/kustomization.yaml
@@ -7,6 +7,6 @@ resources:
 
 labels:
   - pairs:
-      app: lisa
+      app: $(TENANT)
       env: ENV_PLACEHOLDER
-      app.kubernetes.io/name: lisa
+      app.kubernetes.io/name: $(TENANT)

--- a/deployment/k8s/webapp/base/service-account.yaml
+++ b/deployment/k8s/webapp/base/service-account.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: lisa-sa
+  name: $(TENANT)-sa
   annotations:
     eks.amazonaws.com/role-arn: placeholder
 automountServiceAccountToken: false

--- a/deployment/k8s/webapp/base/service.yaml
+++ b/deployment/k8s/webapp/base/service.yaml
@@ -4,8 +4,8 @@ metadata:
   annotations: {}
 
   labels:
-    io.kompose.service: lisa
-  name: lisa
+    io.kompose.service: $(TENANT)
+  name: $(TENANT)
 spec:
   type: NodePort
   ports:
@@ -13,4 +13,4 @@ spec:
       port: 80
       targetPort: 80
   selector:
-    io.kompose.service: lisa
+    io.kompose.service: $(TENANT)

--- a/deployment/k8s/webapp/overlays/dev/lisa-t1/kustomization.yaml
+++ b/deployment/k8s/webapp/overlays/dev/lisa-t1/kustomization.yaml
@@ -2,13 +2,13 @@ resources:
   - ../../../base
   - namespace.yaml
 
-namespace: lisa
+namespace: $(TENANT)
 
 patches:
   - path: patches/service-account.yaml
     target:
       kind: ServiceAccount
-      name: lisa-sa
+      name: $(TENANT)-sa
 
 
 labels:
@@ -21,3 +21,9 @@ images:
     newTag: '1739959086'
 
 
+vars:
+  - name: TENANT
+    objref:
+      kind: Namespace
+      name: lisa
+      apiVersion: v1

--- a/deployment/k8s/webapp/overlays/dev/lisa-t2/kustomization.yaml
+++ b/deployment/k8s/webapp/overlays/dev/lisa-t2/kustomization.yaml
@@ -2,13 +2,13 @@ resources:
   - ../../../base
   - namespace.yaml
 
-namespace: lisa-t2
+namespace: $(TENANT)
 
 patches:
   - path: patches/service-account.yaml
     target:
       kind: ServiceAccount
-      name: lisa-sa
+      name: $(TENANT)-sa
 
 
 labels:
@@ -21,3 +21,9 @@ images:
     newTag: '1739959086'
 
 
+vars:
+  - name: TENANT
+    objref:
+      kind: Namespace
+      name: lisa-t2
+      apiVersion: v1


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
Previous deployment failed due to duplicated deployment resource naming

## Description
Supplied TENANT variable to dynamically name deployment resources on a per-tenant basis
Bootstrap deliberately left as-is due to shared host and parallel work to route based on JWT group membership

## How Has This Been Tested?
Needs deployment.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.