### PR TITLE
fix([DPAV-948]) Ensure Change Stage logs use the same Seq number as other log types

### DIFF
--- a/backend/src/services/incident.ts
+++ b/backend/src/services/incident.ts
@@ -168,17 +168,17 @@ function getReferrer(row: ia.ResultRow, amendments?: Amendments): Referrer | und
     return undefined;
   }
   const referrer: Partial<Referrer> = {
-    name: amendments?.['referrer.name'] || row.referrerName?.value,
-    organisation: amendments?.['referrer.organisation'] || row.referrerOrg?.value,
-    telephone: amendments?.['referrer.telephone'] || row.referrerTel?.value,
-    email: amendments?.['referrer.email'] || row.referrerEmail?.value
+    name: amendments?.['referrer.name'] ?? row.referrerName?.value,
+    organisation: amendments?.['referrer.organisation'] ?? row.referrerOrg?.value,
+    telephone: amendments?.['referrer.telephone'] ?? row.referrerTel?.value,
+    email: amendments?.['referrer.email'] ?? row.referrerEmail?.value
   };
   const supportRequested =
-    amendments?.['referrer.supportRequested'] || row.referrerSupportRequested?.value;
+    amendments?.['referrer.supportRequested'] ?? row.referrerSupportRequested?.value;
   if (supportRequested === 'Yes') {
     referrer.supportRequested = 'Yes';
     referrer.supportDescription =
-      amendments?.['referrer.supportDescription'] || row.referrerSupportDesc?.value;
+      amendments?.['referrer.supportDescription'] ?? row.referrerSupportDesc?.value;
   } else {
     referrer.supportRequested = 'No';
   }
@@ -186,7 +186,7 @@ function getReferrer(row: ia.ResultRow, amendments?: Amendments): Referrer | und
 }
 
 function getName(row: ia.ResultRow, amendments?: Amendments): string {
-  return amendments?.name || row.name?.value;
+  return amendments?.name ?? row.name?.value;
 }
 
 export async function get(_: Request, res: Response) {
@@ -247,7 +247,7 @@ export async function get(_: Request, res: Response) {
 
   const amendmentsByIncident = amendments.reduce((map, row) => {
     const incidentId = nodeValue(row.id.value);
-    const amends = map[incidentId] || {};
+    const amends = map[incidentId] ?? {};
     amends[row.fieldName.value] = row.fieldValue.value;
     return { ...map, [incidentId]: amends };
   }, new Map<string, Amendments>());
@@ -263,8 +263,8 @@ export async function get(_: Request, res: Response) {
         name: getName(row, amendmentsByIncident[nodeValue(row.id.value)]),
         referrer: getReferrer(row, amendmentsByIncident[nodeValue(row.id.value)]),
         reportedBy: {
-          username: row.reportedByName?.value || undefined,
-          displayName: row.reportedByName?.value || undefined
+          username: row.reportedByName?.value ?? undefined,
+          displayName: row.reportedByName?.value ?? undefined
         }
       }) satisfies Incident
   );

--- a/frontend/src/components/AddEntry/index.tsx
+++ b/frontend/src/components/AddEntry/index.tsx
@@ -56,7 +56,7 @@ const AddEntry = ({
   const { users } = useUsers();
   const [entry, setEntry] = useState<Partial<LogEntry>>({
     incidentId: incident?.id,
-    sequence: createSequenceNumber(new Date()),
+    sequence: createSequenceNumber(),
     type: 'General',
     content: {}
   });

--- a/frontend/src/components/EntryList/__tests__/Task.test.tsx
+++ b/frontend/src/components/EntryList/__tests__/Task.test.tsx
@@ -16,7 +16,7 @@ describe('Task Component', () => {
     },
     author: { username: 'author', displayName: 'Author Name' },
     dateTime: '2025-04-02T12:00:00Z',
-    content: {text: "", json: ""},
+    content: { text: '', json: '' },
     type: 'General'
   };
 
@@ -37,5 +37,5 @@ describe('Task Component', () => {
     const noTaskEntry = { ...mockLogEntry, task: undefined };
     providersRender(<Task entry={noTaskEntry} />);
     expect(screen.queryByText('Task name')).not.toBeInTheDocument();
-  });  
+  });
 });

--- a/frontend/src/components/EntryList/__tests__/Task.test.tsx
+++ b/frontend/src/components/EntryList/__tests__/Task.test.tsx
@@ -23,10 +23,10 @@ describe('Task Component', () => {
   it('renders task name, description, and assignee', () => {
     providersRender(<Task entry={mockLogEntry} />);
 
-    expect(screen.getByText('Task name')).toBeInTheDocument();
+    expect(screen.getByText('Task name:')).toBeInTheDocument();
     expect(screen.getByText('Investigate issue')).toBeInTheDocument();
 
-    expect(screen.getByText('Assigned to')).toBeInTheDocument();
+    expect(screen.getByText('Assigned to:')).toBeInTheDocument();
     expect(screen.getByText('jdoe')).toBeInTheDocument();
 
     expect(screen.getByText('Task description')).toBeInTheDocument();

--- a/frontend/src/components/SetInformation/utils.ts
+++ b/frontend/src/components/SetInformation/utils.ts
@@ -33,7 +33,7 @@ function makeEntryFromIncident(incident: Incident, entry?: Partial<LogEntry>): P
     dateTime: '',
     content: {},
     fields: [],
-    sequence: createSequenceNumber(new Date())
+    sequence: createSequenceNumber()
   };
   const type = LogEntryTypes.SetIncidentInformation;
   type?.fields(logEntry).forEach((field) => {

--- a/frontend/src/components/SetInformation/utils.ts
+++ b/frontend/src/components/SetInformation/utils.ts
@@ -18,16 +18,16 @@ function getIncidentValue(incident: Incident, field: Field): string | undefined 
     const parts = id.split('.');
     const obj = incident[parts[0] as keyof Incident];
     if (typeof obj === 'object') {
-      value = String(obj[parts[1] as keyof typeof obj] || '');
+      value = String(obj[parts[1] as keyof typeof obj] ?? '');
     }
   } else {
-    value = String(incident[id as keyof Incident] || '');
+    value = String(incident[id as keyof Incident] ?? '');
   }
   return !value?.length ? undefined : value;
 }
 
 function makeEntryFromIncident(incident: Incident, entry?: Partial<LogEntry>): Partial<LogEntry> {
-  const logEntry: Partial<LogEntry> = entry || {
+  const logEntry: Partial<LogEntry> = entry ?? {
     type: 'SetIncidentInformation',
     incidentId: incident.id,
     dateTime: '',
@@ -61,8 +61,8 @@ export function getDirtyEntry(entry: Partial<LogEntry>, incident: Incident): Par
   };
   dirtyEntry.fields = [];
 
-  const origFields = getInitialEntry(incident).fields || [];
-  const newFields = entry.fields || [];
+  const origFields = getInitialEntry(incident).fields ?? [];
+  const newFields = entry.fields ?? [];
   origFields.forEach((field) => {
     const newField = newFields.find((f) => f.id === field.id);
     if (!newField) {
@@ -95,7 +95,7 @@ export function validate(entry: Partial<LogEntry>, incident: Incident): Validati
   const validationErrors: ValidationError[] = Validate.entry(entry, []);
   const dirtyEntry = getDirtyEntry(entry, incident);
   if (!dirtyEntry.fields?.length) {
-    const origFieldIds = getInitialEntry(incident).fields?.map((f) => f.id) || [];
+    const origFieldIds = getInitialEntry(incident).fields?.map((f) => f.id) ?? [];
     origFieldIds.forEach((fieldId) => {
       validationErrors.push({
         fieldId,

--- a/frontend/src/hooks/Forms/utils.ts
+++ b/frontend/src/hooks/Forms/utils.ts
@@ -13,7 +13,7 @@ export function createLogEntryFromSubmittedForm(formTitle: string, formId: strin
     dateTime: new Date().toISOString(),
     content: {},
     fields: [],
-    sequence: createSequenceNumber(new Date()),
+    sequence: createSequenceNumber(),
     details: {
       submittedFormId: formId,
       submittedFormTitle: formTitle

--- a/frontend/src/hooks/Forms/utils.ts
+++ b/frontend/src/hooks/Forms/utils.ts
@@ -3,10 +3,15 @@
 // and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { LogEntry } from "common/LogEntry";
-import { createSequenceNumber } from "../../utils/Form/sequence";
+import { LogEntry } from 'common/LogEntry';
+import { createSequenceNumber } from '../../utils/Form/sequence';
 
-export function createLogEntryFromSubmittedForm(formTitle: string, formId: string, incidentId: string, entry? : Partial<LogEntry>): Partial<LogEntry>{
+export function createLogEntryFromSubmittedForm(
+  formTitle: string,
+  formId: string,
+  incidentId: string,
+  entry?: Partial<LogEntry>
+): Partial<LogEntry> {
   const logEntry: Partial<LogEntry> = entry ?? {
     type: 'FormSubmitted',
     incidentId,

--- a/frontend/src/hooks/useIncidents.ts
+++ b/frontend/src/hooks/useIncidents.ts
@@ -73,11 +73,12 @@ export const useCreateIncident = () => {
 export const useChangeIncidentStage = () => {
   const queryClient = useQueryClient();
   const createIncident = useMutation<Incident, Error, Incident>({
-    mutationFn: (incident) => post(`/incident/${incident.id}/stage`, {
-      id: incident.id,
-      stage: incident.stage,
-      sequence: createSequenceNumber()
-    }),
+    mutationFn: (incident) =>
+      post(`/incident/${incident.id}/stage`, {
+        id: incident.id,
+        stage: incident.stage,
+        sequence: createSequenceNumber()
+      }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['incidents'] });
     },

--- a/frontend/src/hooks/useIncidents.ts
+++ b/frontend/src/hooks/useIncidents.ts
@@ -9,6 +9,7 @@ import { QueryClient, useMutation, useQuery, useQueryClient } from '@tanstack/re
 // Local imports
 import { type Incident } from 'common/Incident';
 import { FetchError, get, post } from '../api';
+import { createSequenceNumber } from '../utils/Form/sequence';
 
 export const useIncidents = () =>
   useQuery<Incident[], FetchError>({
@@ -72,7 +73,11 @@ export const useCreateIncident = () => {
 export const useChangeIncidentStage = () => {
   const queryClient = useQueryClient();
   const createIncident = useMutation<Incident, Error, Incident>({
-    mutationFn: (incident) => post(`/incident/${incident.id}/stage`, incident),
+    mutationFn: (incident) => post(`/incident/${incident.id}/stage`, {
+      id: incident.id,
+      stage: incident.stage,
+      sequence: createSequenceNumber()
+    }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['incidents'] });
     },

--- a/frontend/src/utils/Form/sequence.ts
+++ b/frontend/src/utils/Form/sequence.ts
@@ -3,7 +3,6 @@
 // and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 export const createSequenceNumber = () => {
-
   const date = new Date();
   return [
     date.getDate(),
@@ -14,4 +13,4 @@ export const createSequenceNumber = () => {
   ]
     .map((element) => String(element).padStart(2, '0'))
     .join('');
-}
+};

--- a/frontend/src/utils/Form/sequence.ts
+++ b/frontend/src/utils/Form/sequence.ts
@@ -2,8 +2,10 @@
 // © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 // and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
-export const createSequenceNumber = (date: Date) =>
-  [
+export const createSequenceNumber = () => {
+
+  const date = new Date();
+  return [
     date.getDate(),
     date.getMonth() + 1, // to account for zero based indexing on the month
     date.getHours(),
@@ -12,3 +14,4 @@ export const createSequenceNumber = (date: Date) =>
   ]
     .map((element) => String(element).padStart(2, '0'))
     .join('');
+}

--- a/frontend/src/utils/Task/updateLogEntries.ts
+++ b/frontend/src/utils/Task/updateLogEntries.ts
@@ -14,7 +14,7 @@ export function createLogEntryFromTaskStatusUpdate(taskId : string, status : Tas
     dateTime: new Date().toISOString(),
     content: {},
     fields: [],
-    sequence: createSequenceNumber(new Date()),
+    sequence: createSequenceNumber(),
     details: {
       changedStatus: status,
       changedTaskId: taskId
@@ -31,7 +31,7 @@ export function createLogEntryFromTaskAssigneeUpdate(taskId : string, assigneeNa
     dateTime: new Date().toISOString(),
     content: {},
     fields: [],
-    sequence: createSequenceNumber(new Date()),
+    sequence: createSequenceNumber(),
     details: {
       changedAssignee: assigneeName,
       changedTaskId: taskId


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
Previously Change Stage log entries were being generated with a sequential number starting form #1 - this was out of step with all other log entry types which use a generated sequence number based on the current date/time.

## Description
Change Stage now uses the same Sequence generating function as all other log types

## How Has This Been Tested?
Verified locally

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/fcbe4456-e621-4baf-8c69-c3787f983aa2)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.