### PR TITLE
fix(NON-REQ): allow Istio patch

### DIFF
--- a/deployment/k8s/backend/base/istio/allow-ingress-authorization-policy.yaml
+++ b/deployment/k8s/backend/base/istio/allow-ingress-authorization-policy.yaml
@@ -14,7 +14,7 @@ spec:
             principals : ["cluster.local/ns/istio-ingress/sa/istio-ingress"]
       to:
         - operation:
-            methods: ["GET","POST","PUT"]
+            methods: ["GET","PATCH", "POST","PUT"]
       when:
         - key: request.auth.claims[groups]
           values:


### PR DESCRIPTION
## Sensitive Credential Checks
- [X] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

## Motivation and Context
Resolves issue observed with updating task status, specifically when using dedicated tenant instances. 

## Description
Currently GET, POST and PUT operations are listed in Istio configuration. When applied to a standard dev, staging or production environment the full ingress rule is patched (https://github.com/National-Digital-Twin/LISA/blob/develop/deployment/k8s/backend/overlays/dev/patches/allow-ingress.yaml), which removes the specific verb requirements. For dedicated instances, the verbs are kept (as only the group is patched), such as at https://github.com/National-Digital-Twin/LISA/blob/develop/deployment/k8s/backend/overlays/iwc/dev/patches/allow-ingress.yaml. This being the case, when a PATCH operation is sent to update a task status, this cannot be routed properly. This adds an allow rule for inbound patch requests to resolve this.

## How Has This Been Tested?
To be tested in remote deployment environment behind Istio ingress.

## Checklist:
- [X] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.