### PR TITLE
bugfix(DPAV-1153) Disallow user changing label to text to bypass form label restrictions

### DIFF
--- a/frontend/src/components/CustomForms/FormTemplates/FormBuilder.tsx
+++ b/frontend/src/components/CustomForms/FormTemplates/FormBuilder.tsx
@@ -30,6 +30,7 @@ import SortableFieldRow from "./SortableFieldRow"
 import { generateFieldKey } from '../utils';
 import { Field } from './types';
 import { useCreateFormTemplate } from '../../../hooks/Forms/useFormTemplates';
+import { MAX_FORM_LABEL_LENGTH } from '../constants';
 
 type Props = {
   onSchemaChange: (schema: JSONSchema7, uiSchema: UiSchema) => void;
@@ -140,6 +141,11 @@ const FormBuilder = ({ onSchemaChange }: Props) => {
         if (!field.options || field.options.length === 0) {
           errors[field.id] = 'Dropdown must have at least one option.';
         }
+      }
+
+
+      if(label.length > MAX_FORM_LABEL_LENGTH) {
+        errors[field.id] = `Label must be less than ${MAX_FORM_LABEL_LENGTH} characters`
       }
     });
   

--- a/frontend/src/components/CustomForms/FormTemplates/SortableFieldRow.tsx
+++ b/frontend/src/components/CustomForms/FormTemplates/SortableFieldRow.tsx
@@ -27,6 +27,7 @@ import {
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { Field } from './types';
+import { MAX_FORM_LABEL_LENGTH } from '../constants';
 
 interface SortableFieldRowProps {
   id: string;
@@ -105,7 +106,7 @@ const SortableFieldRow: React.FC<SortableFieldRowProps> = ({
             inputProps={
               field.type !== 'label'
                 ? {
-                  maxLength: 500
+                  maxLength: MAX_FORM_LABEL_LENGTH
                 }
                 : undefined
             }

--- a/frontend/src/components/CustomForms/constants.ts
+++ b/frontend/src/components/CustomForms/constants.ts
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+// and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
+
+export const MAX_FORM_LABEL_LENGTH = 500;


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

## Motivation and Context
DPAV-1153

## Description
 - Added extra validation to stop user swapping a label field to a text field to bypass length restrictions

## How Has This Been Tested?
Tested locally and verified

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/7fe1a811-6eb8-4568-9842-b5673a8d6ac9)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.