### PR TITLE
bugfix(DPAV-1151): logout on query 401/403

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -13,6 +13,7 @@ import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client
 // Local imports
 import App from './App';
 import { FetchError, post } from './api';
+import { logout } from './utils/auth';
 
 // Styles
 import './App.scss';
@@ -22,21 +23,17 @@ const persister = createSyncStoragePersister({
   storage: window.localStorage
 });
 
+const onError = async (error: FetchError) => {
+  if (error.status === 302) {
+    document.location = error.redirectUrl!;
+  } else if (error.status === 401 || error.status === 403) {
+    await logout();
+  }
+};
+
 const queryClient = new QueryClient({
-  queryCache: new QueryCache({
-    onError: (error: FetchError) => {
-      if (error.status === 302) {
-        document.location = error.redirectUrl!;
-      }
-    }
-  }),
-  mutationCache: new MutationCache({
-    onError: (error: FetchError) => {
-      if (error.status === 302) {
-        document.location = error.redirectUrl!;
-      }
-    }
-  })
+  queryCache: new QueryCache({ onError }),
+  mutationCache: new MutationCache({ onError })
 });
 
 queryClient.setMutationDefaults(['createIncident'], {

--- a/frontend/src/providers/AuthContextProvider.tsx
+++ b/frontend/src/providers/AuthContextProvider.tsx
@@ -8,21 +8,7 @@ import type { User } from 'common/User';
 import { FetchError, get } from '../api';
 import { AuthContextType } from '../utils/types';
 import { AuthContext } from '../context/AuthContext';
-
-async function clearServiceWorkerCaches() {
-  // Clear service worker cache
-  if ('caches' in window) {
-    await caches.keys().then((cacheNames) => {
-      Promise.all(cacheNames.map((cacheName) => caches.delete(cacheName)));
-    });
-  }
-}
-
-function clearLocalAndSessionStorage() {
-  // Handle client-side storage
-  localStorage.clear();
-  sessionStorage.clear();
-}
+import { logout } from '../utils/auth';
 
 const AuthContextProvider = ({ children }: PropsWithChildren) => {
   const [offline, setOffline] = useState<boolean>(true);
@@ -31,25 +17,6 @@ const AuthContextProvider = ({ children }: PropsWithChildren) => {
     queryFn: () => get('/auth/user'),
     retry: false
   });
-
-  const logout = async () => {
-    await fetch('/api/auth/logout-links').then(
-      async (response) => {
-        if (response.ok) {
-          const logoutLinks = await response.json();
-          await clearServiceWorkerCaches();
-          clearLocalAndSessionStorage();
-          await fetch(logoutLinks.oAuthLogoutUrl, { method: 'GET', redirect: 'manual', credentials: 'include' });
-          document.location = logoutLinks.redirect;
-        } else {
-          document.location = '/';
-        }
-      },
-      () => {
-        document.location = '/';
-      }
-    );
-  };
 
   useEffect(() => {
     const isOffline = error?.message === 'Failed to fetch';

--- a/frontend/src/utils/Map/loadLocations.ts
+++ b/frontend/src/utils/Map/loadLocations.ts
@@ -9,10 +9,9 @@ import { Search } from '../Search';
 import { type AsyncReturnType } from '../types';
 
 type CallbackType = (options: AsyncReturnType<typeof Search.location>) => void;
-type Type = (inputValue: string | Coordinates, callback: CallbackType) => void;
 
 function searchLocation(inputValue: string | Coordinates, callback: CallbackType) {
   Search.location(inputValue).then((options) => callback(options));
 }
 
-export const loadLocations: Type = debounce(searchLocation, 500);
+export const loadLocations = debounce(searchLocation, 500);

--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+// and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
+
+async function clearServiceWorkerCaches() {
+  // Clear service worker cache
+  if ('caches' in window) {
+    await caches.keys().then((cacheNames) => {
+      Promise.all(cacheNames.map((cacheName) => caches.delete(cacheName)));
+    });
+  }
+}
+
+function clearLocalAndSessionStorage() {
+  // Handle client-side storage
+  localStorage.clear();
+  sessionStorage.clear();
+}
+
+export async function logout() {
+  let redirect = '/';
+  try {
+    const response = await fetch('/api/auth/logout-links');
+    if (response.ok) {
+      const logoutLinks = await response.json();
+
+      await clearServiceWorkerCaches();
+      clearLocalAndSessionStorage();
+
+      await fetch(logoutLinks.oAuthLogoutUrl, {
+        method: 'GET',
+        redirect: 'manual',
+        credentials: 'include'
+      });
+
+      redirect = logoutLinks.redirect;
+    }
+  } catch {
+    throw new Error('Failed to logout');
+  }
+
+  if (document.location.pathname !== redirect) {
+    document.location = redirect;
+  }
+}

--- a/frontend/src/utils/debounce.ts
+++ b/frontend/src/utils/debounce.ts
@@ -2,15 +2,13 @@
 // © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 // and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export function debounce(fn: Function, delay: number = 250) {
-  // eslint-disable-next-line no-undef
-  let timeout: NodeJS.Timeout;
+export function debounce<T extends (...args: never[]) => void>(fn: T, delay: number = 250): T {
+  let timeout: ReturnType<typeof setTimeout>;
 
-  return (...args: unknown[]) => {
+  return ((...args: Parameters<T>) => {
     clearTimeout(timeout);
     timeout = setTimeout(() => {
       fn(...args);
     }, delay);
-  };
+  }) as T;
 }


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
If authentication cookie is expired, or removed a 403 is returned from all API reqs (HTML page with a window.location redirect). There is no handling for anything other than a 302 at the minute so the app continues to look like its working when all requests are failing.

https://ndtp.atlassian.net/browse/DPAV-1151

## Description
Handle 401/403 and logout the user, redirecting to the logout url.

(Also contains lint fix that prevented me committing)

## How Has This Been Tested?
Locally by returning a 403 from backend requests

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.