### PR TITLE
bugfix(DPAV-1151): Redirect to landing page on 401/403

### DIFF
--- a/backend/src/services/auth.ts
+++ b/backend/src/services/auth.ts
@@ -50,8 +50,9 @@ export async function user(_req: Request, res: Response) {
 }
 
 export async function logoutLinks(_req: Request, res: Response) {
+  const landingPageUrl = settings.LANDING_PAGE_URL;
   if (settings.NODE_ENV === 'development') {
-    return res.json({ oAuthLogoutUrl: '/', redirect: '/' });
+    return res.json({ oAuthLogoutUrl: '/', redirect: '/', landingPageUrl });
   }
 
   try {
@@ -65,7 +66,7 @@ export async function logoutLinks(_req: Request, res: Response) {
     }
 
     const logoutRedirect = await response.json();
-    return res.json({ oAuthLogoutUrl, redirect: logoutRedirect.href });
+    return res.json({ oAuthLogoutUrl, redirect: logoutRedirect.href, landingPageUrl });
   } catch (error) {
     throw new ApplicationError(error);
   }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -10,24 +10,46 @@ import { ThemeProvider } from '@mui/material/styles';
 import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister';
 import { MutationCache, QueryCache, QueryClient } from '@tanstack/react-query';
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client';
+
 // Local imports
 import App from './App';
 import { FetchError, post } from './api';
-import { logout } from './utils/auth';
 
 // Styles
 import './App.scss';
 import theme from './theme';
 
+interface LogoutLinks {
+  oAuthLogoutUrl: string;
+  redirect: string;
+  landingPageUrl: string;
+}
+
 const persister = createSyncStoragePersister({
   storage: window.localStorage
 });
+
+let cachedLandingPageUrl: string | null = null;
+const fetchLandingPageUrl = async (): Promise<void> => {
+  try {
+    const response = await fetch('/api/auth/logout-links');
+    if (response.ok) {
+      const logoutLinks: LogoutLinks = await response.json();
+      cachedLandingPageUrl = logoutLinks.landingPageUrl;
+    }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn('Failed to fetch logout links config:', error);
+  }
+};
 
 const onError = async (error: FetchError) => {
   if (error.status === 302) {
     document.location = error.redirectUrl!;
   } else if (error.status === 401 || error.status === 403) {
-    await logout();
+    if (cachedLandingPageUrl) {
+      document.location = cachedLandingPageUrl;
+    }
   }
 };
 
@@ -53,3 +75,5 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <ReactQueryDevtools />
   </PersistQueryClientProvider>
 );
+
+fetchLandingPageUrl();


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
The previous change to logout on 401/403 didn't work.

## Description
The previous fix wasn't working as we are unable to call any apis
once the authentication is expired, they will all result in the
oauth2-proxy 403 HTML response.

Now we will fetch the landing page url at startup and save it for
later to use for redirecting. As they won't be able to load the
app without valid authentication this will work as intended (without
a valid cookie they would be redirected before the request made it
to the web app).

## How Has This Been Tested?
Locally

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.