### PR TITLE
bugfix(DPAV-1148) State issue resolved with triggering notification fetch

### DIFF
--- a/frontend/src/components/NotificationsMenu/NotificationsMenu.tsx
+++ b/frontend/src/components/NotificationsMenu/NotificationsMenu.tsx
@@ -22,18 +22,14 @@ export default function NotificationsMenu() {
   const { notifications, invalidate } = useNotifications();
   const readNotification = useReadNotification();
   const { user } = useAuth();
-  const hasNewNotifications = useMessaging('NewNotification', user?.current?.username);
+  const [hasNewNotifications, resetNewNotifications] = useMessaging('NewNotification', user?.current?.username);
 
   useEffect(() => {
-    /* eslint-disable-next-line no-console */
-    console.log('responding to hasNewNotifications')
-    if (!hasNewNotifications) {
-      /* eslint-disable-next-line no-console */
-      console.log('hasNewNotifications false')
-      // return;
+    if (hasNewNotifications) {
+      invalidate();
+      resetNewNotifications();
     }
-    invalidate();
-  }, [hasNewNotifications, invalidate]);
+  }, [hasNewNotifications, invalidate, resetNewNotifications]);
 
   const onItemClick = (notification: Notification) => {
     setAnchorEl(null);

--- a/frontend/src/components/NotificationsMenu/__tests__/NotificationsMenu.test.tsx
+++ b/frontend/src/components/NotificationsMenu/__tests__/NotificationsMenu.test.tsx
@@ -63,7 +63,7 @@ jest.mock('../../../hooks', () => ({
   }))
 }));
 
-jest.mock('../../../hooks/useMessaging', () => jest.fn(() => false));
+jest.mock('../../../hooks/useMessaging', () => jest.fn(() => [false, jest.fn()]));
 
 // Mock getHandler used by NotificationItem so that the title and content come from the notification
 jest.mock('../handlers', () => ({
@@ -127,7 +127,7 @@ describe('NotificationsMenu Component', () => {
 
   it('calls invalidate when new notifications are received (via useMessaging hook)', () => {
     // Override useMessaging to simulate new notifications being received
-    (useMessaging as jest.Mock).mockReturnValue(true);
+    (useMessaging as jest.Mock).mockReturnValue([true, jest.fn()]);
 
     render(<NotificationsMenu />);
     // The hook effect should call invalidate if new notifications have arrived.

--- a/frontend/src/hooks/__tests__/useMessaging.test.tsx
+++ b/frontend/src/hooks/__tests__/useMessaging.test.tsx
@@ -72,7 +72,7 @@ describe('useMessaging', () => {
     // Render the hook and capture its result so we can inspect the state.
     const { result, unmount } = renderHook(() => useMessaging(topic, subject), { wrapper });
 
-    let [initialHasMessage, resetHasMessage] = result.current;
+    const [initialHasMessage, resetHasMessage] = result.current;
 
     // Initially, since no message has been received, it should return false.
     expect(initialHasMessage).toBe(false);

--- a/frontend/src/hooks/__tests__/useMessaging.test.tsx
+++ b/frontend/src/hooks/__tests__/useMessaging.test.tsx
@@ -88,13 +88,9 @@ describe('useMessaging', () => {
       expect(hasMessageAfterCallback).toBe(true);
     });
 
-    // After state update, check reset function
-    const [, reset] = result.current;
-    expect(typeof reset).toBe('function');
-
     // Call reset function
     act(() => {
-      reset();
+      resetHasMessage();
     });
 
     // Wait for state to reset back to false

--- a/frontend/src/hooks/__tests__/useMessaging.test.tsx
+++ b/frontend/src/hooks/__tests__/useMessaging.test.tsx
@@ -72,11 +72,10 @@ describe('useMessaging', () => {
     // Render the hook and capture its result so we can inspect the state.
     const { result, unmount } = renderHook(() => useMessaging(topic, subject), { wrapper });
 
-    // Initially, since no message has been received, it should return false.
-    expect(result.current).toBe(false);
+    let [initialHasMessage, resetHasMessage] = result.current;
 
-    // At this point our subscribeMock should have captured the callback.
-    expect(capturedCallback).toBeDefined();
+    // Initially, since no message has been received, it should return false.
+    expect(initialHasMessage).toBe(false);
 
     // Simulate receiving a message using act.
     act(() => {
@@ -85,7 +84,23 @@ describe('useMessaging', () => {
 
     // Wait for the state update using waitFor.
     await waitFor(() => {
-      expect(result.current).toBe(false);
+      const [hasMessageAfterCallback] = result.current;
+      expect(hasMessageAfterCallback).toBe(true);
+    });
+
+    // After state update, check reset function
+    const [, reset] = result.current;
+    expect(typeof reset).toBe('function');
+
+    // Call reset function
+    act(() => {
+      reset();
+    });
+
+    // Wait for state to reset back to false
+    await waitFor(() => {
+      const [hasMessageAfterReset] = result.current;
+      expect(hasMessageAfterReset).toBe(false);
     });
 
     unmount();

--- a/frontend/src/hooks/useMessaging.ts
+++ b/frontend/src/hooks/useMessaging.ts
@@ -11,13 +11,11 @@ import { MessagingContext } from '../context/MessagingContext';
 import { MessagingContextType } from '../utils/types';
 
 
-export default function useMessaging(topic: MessagingTopicType, subject?: string) {
+export default function useMessaging(topic: MessagingTopicType, subject?: string): [boolean, () => void] {
   const { subscribe, unsubscribe } = useContext(MessagingContext) as MessagingContextType;
   const [hasMessage, setHasMessage] = useState<boolean>(false);
 
   const callback = useCallback(() => {
-    /* eslint-disable-next-line no-console */
-    console.log('hasMessage true');
     setHasMessage(true);
   }, []);
 
@@ -32,11 +30,5 @@ export default function useMessaging(topic: MessagingTopicType, subject?: string
     };
   }, [topic, subject, subscribe, unsubscribe, callback]);
 
-  useEffect(() => {
-    /* eslint-disable-next-line no-console */
-    console.log('hasMessage false');
-    setHasMessage(false);
-  }, [hasMessage]);
-
-  return hasMessage;
+  return [hasMessage, () => setHasMessage(false)];
 }


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
Due to overlayed useEffects in code, there is a random chance (in between frames/renders) that the fetch for Notifications will not be triggered and therefore notifications are missed by the end user unless they refresh.

This is one half of the work to make notifications work, to be paired with a polling approach for when the fetch is triggered but the notification is not yet present in the IA node.

## Description
Modified steps so that the state is only reset when the WS message has been processed, sidestepping the issue whereby the flag for a new notification is set and reset as part of the same render cycle.

## How Has This Been Tested?
Needs deploying to test fully alongside other changes to poll for notifications.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.