### PR TITLE
bugfix(dpav-1148): added polling mechanism to fetch updates to notifications

### DIFF
--- a/backend/src/services/notifications/index.ts
+++ b/backend/src/services/notifications/index.ts
@@ -36,24 +36,20 @@ export async function markRead(req: Request, res: Response) {
     clause: [
       ['?id', ns.rdf.type, '?type'],
       ['?id', ns.lisa.hasRecipient, '?recipient'],
-      sparql.optional([
-        ['?id', ns.lisa.readAt, '?read'],
-      ]),
+      sparql.optional([['?id', ns.lisa.readAt, '?read']])
     ],
     filters: [
       sparql.in('?recipient', [ns.data(username)]),
       sparql.in('?id', [idNode]),
-      sparql.in('?type', getTypesList()),
+      sparql.in('?type', getTypesList())
     ]
   });
 
   if (results.length === 1 && !results[0].read?.value) {
-    await ia.insertData([
-      [idNode, ns.lisa.readAt, literalDate(new Date())]
-    ]);
+    await ia.insertData([[idNode, ns.lisa.readAt, literalDate(new Date())]]);
   }
 
-  res.status(204).send();
+  res.json({ id });
 }
 
 export async function get(req: Request, res: Response) {
@@ -69,18 +65,11 @@ export async function get(req: Request, res: Response) {
       ['?id', ns.lisa.hasIncident, '?incidentId'],
       ['?entryId', ns.ies.inPeriod, '?dateTime'],
       ['?entryId', ns.lisa.hasSequence, '?sequence'],
-      sparql.optional([
-        ['?id', ns.lisa.readAt, '?read']
-      ]),
+      sparql.optional([['?id', ns.lisa.readAt, '?read']]),
       ...optionals
     ],
-    filters: [
-      sparql.in('?recipient', [ns.data(username)]),
-      sparql.in('?type', getTypesList())
-    ],
-    orderBy: [
-      ['?createdAt', 'DESC']
-    ]
+    filters: [sparql.in('?recipient', [ns.data(username)]), sparql.in('?type', getTypesList())],
+    orderBy: [['?createdAt', 'DESC']]
   });
 
   const notifications: Notification[] = results.map(parseNotification);

--- a/developer_docs/RUN_MULTIPLE_USERS.md
+++ b/developer_docs/RUN_MULTIPLE_USERS.md
@@ -1,0 +1,38 @@
+# RUN_MULTIPLE_USERS.md
+
+This document outlines how to run the LISA application to test multiple user functionality.
+
+## The setup
+
+In order to run multiple users for LISA we are going to be running two instances of the frontend that are going to connect to the same instance of the backend.
+
+## Prereqisites
+
+- Create a copy of the LISA repository
+
+## Changes to the backend
+
+- In the `src/services/auth.ts` add the following lines of code to the `getUserDetails` method:
+
+```typescript
+if (req.header('X-FE2')) {
+   return new User('local.user.2', 'local.user.2@example.com', 'Local User 2');
+}
+```
+
+- In the `src/auth/cognito.ts` add the following lines of code to the `getUsers` method:
+
+```typescript
+return resp.Users?.map(cognitoUserToUserListItem).concat([
+   { username: 'local.user', displayName: 'Local User' },
+   { username: 'local.user.2', displayName: 'Local User 2' }
+]);
+```
+
+## Changes to the second instance of the frontend
+
+- In the `src/api/index.ts` add the following line of code to the `getHeaders` method:
+
+```typescript
+headers['X-FE2'] = "FE2";
+```

--- a/frontend/src/components/NotificationsMenu/NotificationsMenu.tsx
+++ b/frontend/src/components/NotificationsMenu/NotificationsMenu.tsx
@@ -14,6 +14,7 @@ import { bem } from '../../utils';
 import { useAuth, useNotifications, useReadNotification } from '../../hooks';
 import useMessaging from '../../hooks/useMessaging';
 import { useResponsive } from '../../hooks/useResponsiveHook';
+import { pollForTotalNotifications } from '../../hooks/useNotifications';
 
 export default function NotificationsMenu() {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -22,14 +23,25 @@ export default function NotificationsMenu() {
   const { notifications, invalidate } = useNotifications();
   const readNotification = useReadNotification();
   const { user } = useAuth();
-  const [hasNewNotifications, resetNewNotifications] = useMessaging('NewNotification', user?.current?.username);
+  const [hasNewNotifications, resetNewNotifications] = useMessaging(
+    'NewNotification',
+    user?.current?.username
+  );
 
   useEffect(() => {
     if (hasNewNotifications) {
-      invalidate();
-      resetNewNotifications();
+      setTimeout(
+        () =>
+          pollForTotalNotifications(
+            notifications?.length ?? 0,
+            1,
+            invalidate,
+            resetNewNotifications
+          ),
+        1000
+      );
     }
-  }, [hasNewNotifications, invalidate, resetNewNotifications]);
+  }, [hasNewNotifications, notifications, invalidate, resetNewNotifications]);
 
   const onItemClick = (notification: Notification) => {
     setAnchorEl(null);

--- a/frontend/src/hooks/useLogEntriesUpdates.tsx
+++ b/frontend/src/hooks/useLogEntriesUpdates.tsx
@@ -10,7 +10,7 @@ import { useToast } from './useToasts';
 
 export function useLogEntriesUpdates(incidentId: string) {
   const queryClient = useQueryClient();
-  const hasNewLogEntries = useMessaging('NewLogEntries', incidentId);
+  const [hasNewLogEntries, resetNewLogEntries] = useMessaging('NewLogEntries', incidentId);
   const postToast = useToast();
 
   useEffect(() => {
@@ -39,5 +39,7 @@ export function useLogEntriesUpdates(incidentId: string) {
       ),
       isDismissable: true
     });
-  }, [incidentId, queryClient, postToast, hasNewLogEntries]);
+
+    resetNewLogEntries();
+  }, [incidentId, queryClient, postToast, hasNewLogEntries, resetNewLogEntries]);
 }

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -2,7 +2,7 @@
 // © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 // and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { QueryClient, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { type Notification } from 'common/Notification';
 import { useCallback } from 'react';
 
@@ -25,14 +25,90 @@ export function useNotifications() {
   return { notifications: data, isLoading, isError, error, invalidate };
 }
 
-export function useReadNotification() {
-  const queryClient = useQueryClient();
-  const readNotification = useMutation<void, Error, string>({
-    mutationFn: (id: string) => put(`/notifications/${id}`, {}),
-    onSettled: async () =>
+export async function pollForTotalNotifications(
+  totalCurrentNotifications: number,
+  attemptNumber: number,
+  invalidateNotifications: () => void,
+  resetNewNotifications: () => void
+) {
+  const notifications = await get<Notification[]>('/notifications');
+
+  if (attemptNumber <= 10) {
+    if (notifications.length > totalCurrentNotifications) {
+      invalidateNotifications();
+      resetNewNotifications();
+    } else {
+      setTimeout(
+        () =>
+          pollForTotalNotifications(
+            totalCurrentNotifications,
+            attemptNumber + 1,
+            invalidateNotifications,
+            resetNewNotifications
+          ),
+        10000
+      );
+    }
+  } else {
+    invalidateNotifications();
+    resetNewNotifications();
+  }
+}
+
+async function pollForReadNotifications(
+  notificationId: string,
+  attemptNumber: number,
+  queryClient: QueryClient
+) {
+  const notifications = await get<Notification[]>('/notifications');
+
+  if (attemptNumber <= 10) {
+    if (
+      notifications.find((notification) => notification.id === notificationId && notification.read)
+    ) {
       queryClient.invalidateQueries({
         queryKey: ['notifications']
-      })
+      });
+    } else {
+      setTimeout(
+        () => pollForReadNotifications(notificationId, attemptNumber + 1, queryClient),
+        10000
+      );
+    }
+  } else {
+    queryClient.invalidateQueries({
+      queryKey: ['notifications']
+    });
+  }
+}
+
+export function useReadNotification() {
+  const queryClient = useQueryClient();
+  const readNotification = useMutation<{ id: string }, Error, string>({
+    mutationFn: (id: string) => put(`/notifications/${id}`, {}),
+    onSuccess: async (data) =>
+      setTimeout(() => pollForReadNotifications(data.id, 1, queryClient), 1000),
+    onMutate: async (id: string) => {
+      await queryClient.cancelQueries({ queryKey: ['notifications'] });
+      const notifications = queryClient.getQueryData<Notification[]>(['notifications']);
+
+      if (notifications) {
+        const otherNotifications: Notification[] = notifications!.filter(
+          (notification) => notification.id !== id
+        );
+        const notificationToBeUpdated: Notification | undefined = notifications!.find(
+          (notification) => notification.id === id
+        );
+
+        if (notificationToBeUpdated) {
+          const updatedNotifications: Notification[] = [
+            ...otherNotifications,
+            { ...notificationToBeUpdated, read: true }
+          ];
+          queryClient.setQueryData<Notification[]>(['notifications'], updatedNotifications);
+        }
+      }
+    }
   });
   return readNotification;
 }


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The notification is being sent to the user before it is saved to the IA node. This is causing an issue where the user is alerted that there is a new notification before they are able to see what it relates to.

## Description
<!--- Describe your changes in detail -->
- Added code to poll for notifications when a trigger is required to fetch them
- Added code to poll for notifications when they are marked as read
- Added optimistic updates for the call to mark the notifications as read.
- Added documentation to run multiple users for LISA locally.
- Added fix to the log entry toast appearing indefinitely when a new log entry is added.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested locally and is working e2e.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.