### PR TITLE
bugfix(dpav-1148): fixed issue with user notifications

### DIFF
--- a/backend/src/pubSub/manager.ts
+++ b/backend/src/pubSub/manager.ts
@@ -47,7 +47,11 @@ export default class PubSubManager {
     }
 
     if (actionResult.value === 'Subscribe') {
-      if (!this.subscribers.find((sub) => sub.id === id && sub.topic === topic && sub.subject === subject)) {
+      if (
+        !this.subscribers.find(
+          (sub) => sub.id === id && sub.topic === topic && sub.subject === subject
+        )
+      ) {
         this.subscribers.push({
           id,
           subject,
@@ -57,8 +61,13 @@ export default class PubSubManager {
         });
       }
     } else {
-      this.subscribers = this.subscribers
-        .filter((sub) => sub.id !== id && sub.topic !== topic && sub.subject !== subject);
+      this.subscribers = this.subscribers.filter((sub) => {
+        if (sub.id === id) {
+          return sub.topic !== topic && sub.subject !== subject;
+        }
+
+        return true;
+      });
     }
   }
 

--- a/frontend/src/hooks/__tests__/pollForReadNotifications.test.tsx
+++ b/frontend/src/hooks/__tests__/pollForReadNotifications.test.tsx
@@ -1,0 +1,78 @@
+import { type Notification } from 'common/Notification';
+import { QueryClient } from '@tanstack/react-query';
+import { get } from '../../api';
+import { pollForReadNotifications } from '../useNotifications';
+
+jest.mock('../../api', () => ({
+  get: jest.fn()
+}));
+
+describe('pollForReadNotifications', () => {
+  let queryClient: QueryClient;
+  const notificationToBeReadId: string = 'notification-1';
+  const notificationToBeRead: Notification = {
+    id: notificationToBeReadId,
+    dateTime: '1970-01-01',
+    recipient: 'local.user',
+    read: false,
+    entry: {
+      id: 'entry-0',
+      dateTime: '1970-01-01',
+      content: { text: '#1235 - Testing 02' },
+      incidentId: 'incident-0',
+      sequence: '0'
+    }
+  };
+  const previousNotifications: Notification[] = [
+    {
+      id: 'notification-0',
+      dateTime: '1970-01-01',
+      read: true,
+      recipient: 'local.user',
+      entry: {
+        id: 'entry-0',
+        dateTime: '1970-01-01',
+        content: { text: '#1234 - Testing 01' },
+        incidentId: 'incident-0',
+        sequence: '0'
+      }
+    }
+  ];
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    queryClient = {
+      invalidateQueries: jest.fn(() => Promise.resolve()),
+      setQueryData: jest.fn(),
+      getQueryData: jest.fn(),
+      cancelQueries: jest.fn()
+    } as unknown as QueryClient;
+
+    (get as jest.Mock).mockClear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should invalidate queries immediately when a matching read notification is found with the provided id', async () => {
+    (get as jest.Mock).mockResolvedValueOnce([
+      { ...notificationToBeRead, read: true },
+      ...previousNotifications
+    ]);
+
+    await pollForReadNotifications(notificationToBeReadId, 1, queryClient);
+
+    expect(get).toHaveBeenCalledWith<unknown[]>('/notifications');
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['notifications'] });
+  });
+
+  it('should invalidate queries when the attempt number is greater than 10', async () => {
+    (get as jest.Mock).mockResolvedValueOnce([notificationToBeRead, ...previousNotifications]);
+
+    await pollForReadNotifications(notificationToBeReadId, 11, queryClient);
+
+    expect(get).toHaveBeenCalledWith<unknown[]>('/notifications');
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['notifications'] });
+  });
+});

--- a/frontend/src/hooks/__tests__/pollForTotalNotifications.test.tsx
+++ b/frontend/src/hooks/__tests__/pollForTotalNotifications.test.tsx
@@ -1,0 +1,87 @@
+import { type Notification } from 'common/Notification';
+import { get } from '../../api';
+import { pollForTotalNotifications } from '../useNotifications';
+
+jest.mock('../../api', () => ({
+  get: jest.fn()
+}));
+
+describe('pollForTotalNotifications', () => {
+  const notificationToBeRead: Notification = {
+    id: 'notification-1',
+    dateTime: '1970-01-01',
+    recipient: 'local.user',
+    read: false,
+    entry: {
+      id: 'entry-0',
+      dateTime: '1970-01-01',
+      content: { text: '#1235 - Testing 02' },
+      incidentId: 'incident-0',
+      sequence: '0'
+    }
+  };
+  const previousNotifications: Notification[] = [
+    {
+      id: 'notification-0',
+      dateTime: '1970-01-01',
+      read: true,
+      recipient: 'local.user',
+      entry: {
+        id: 'entry-0',
+        dateTime: '1970-01-01',
+        content: { text: '#1234 - Testing 01' },
+        incidentId: 'incident-0',
+        sequence: '0'
+      }
+    }
+  ];
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    (get as jest.Mock).mockClear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('calls the invalidate function when the amount of notifications are increased', async () => {
+    const invalidate: () => void = jest.fn();
+    (get as jest.Mock).mockResolvedValueOnce([notificationToBeRead, ...previousNotifications]);
+
+    await pollForTotalNotifications(1, 1, invalidate, jest.fn());
+
+    expect(get).toHaveBeenCalledWith<unknown[]>('/notifications');
+    expect(invalidate).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls the invalidate function when the attempt number is greater than 10', async () => {
+    const invalidate: () => void = jest.fn();
+    (get as jest.Mock).mockResolvedValueOnce([...previousNotifications]);
+
+    await pollForTotalNotifications(1, 11, invalidate, jest.fn());
+
+    expect(get).toHaveBeenCalledWith<unknown[]>('/notifications');
+    expect(invalidate).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls the reset new notifications function when the amount of notifications are increased', async () => {
+    (get as jest.Mock).mockResolvedValueOnce([notificationToBeRead, ...previousNotifications]);
+    const resetNewNotifications: () => void = jest.fn();
+
+    await pollForTotalNotifications(1, 1, jest.fn(), resetNewNotifications);
+
+    expect(get).toHaveBeenCalledWith<unknown[]>('/notifications');
+    expect(resetNewNotifications).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls the reset new notifications function when attempt number is greater than 10', async () => {
+    (get as jest.Mock).mockResolvedValueOnce([...previousNotifications]);
+    const resetNewNotifications: () => void = jest.fn();
+
+    await pollForTotalNotifications(1, 11, jest.fn(), resetNewNotifications);
+
+    expect(get).toHaveBeenCalledWith<unknown[]>('/notifications');
+    expect(resetNewNotifications).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/hooks/__tests__/useNotifications.test.tsx
+++ b/frontend/src/hooks/__tests__/useNotifications.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useNotifications, useReadNotification } from '../useNotifications';
-import { get, put } from '../../api';
+import { useNotifications } from '../useNotifications';
+import { get } from '../../api';
 
 jest.mock('../../api');
 
@@ -39,35 +39,6 @@ describe('useNotifications', () => {
       await result.current.invalidate();
     });
 
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['notifications'] });
-    invalidateSpy.mockRestore();
-  });
-});
-
-describe('useReadNotification', () => {
-  beforeEach(() => {
-    jest.resetAllMocks();
-  });
-
-  it('calls API to mark notification as read and invalidates notifications', async () => {
-    const notificationId = '123';
-    (put as jest.Mock).mockResolvedValueOnce(undefined);
-
-    // Reuse the helper to obtain the wrapper and queryClient.
-    const { wrapper, queryClient } = createWrapper();
-    const { result } = renderHook(() => useReadNotification(), {
-      wrapper
-    });
-
-    // Spy on the invalidateQueries method.
-    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
-
-    // Trigger the mutation.
-    await act(async () => {
-      await result.current.mutateAsync(notificationId);
-    });
-
-    expect(put).toHaveBeenCalledWith(`/notifications/${notificationId}`, {});
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['notifications'] });
     invalidateSpy.mockRestore();
   });

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -55,7 +55,7 @@ export async function pollForTotalNotifications(
   }
 }
 
-async function pollForReadNotifications(
+export async function pollForReadNotifications(
   notificationId: string,
   attemptNumber: number,
   queryClient: QueryClient
@@ -102,8 +102,8 @@ export function useReadNotification() {
 
         if (notificationToBeUpdated) {
           const updatedNotifications: Notification[] = [
-            ...otherNotifications,
-            { ...notificationToBeUpdated, read: true }
+            { ...notificationToBeUpdated, read: true },
+            ...otherNotifications
           ];
           queryClient.setQueryData<Notification[]>(['notifications'], updatedNotifications);
         }


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The user was not receiving notifications about them being mentioned in a log entry outside the log entry area.

## Description
<!--- Describe your changes in detail -->
- Updated the logic to unsubscribe users from a topic to only unsubscribe them from the specific topic that was provided in the unsubscribe message rather than all of the topics.
- Updated tests

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested locally and is working e2e.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.