### PR TITLE
bugfix(dpav-1155): added expand more icon to groups in log entry

### DIFF
--- a/frontend/src/components/Form/FormGroup.tsx
+++ b/frontend/src/components/Form/FormGroup.tsx
@@ -5,6 +5,7 @@
 // Global imports
 import { ElementType } from 'react';
 import { Accordion, AccordionDetails, AccordionSummary, Box, Typography } from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
 // Local imports
 import { type Field } from 'common/Field';
@@ -44,7 +45,10 @@ export default function FormGroup({
   if (group.label) {
     return (
       <Accordion defaultExpanded={group.defaultOpen} elevation={0}>
-        <AccordionSummary sx={{ backgroundColor: 'border.default' }}>
+        <AccordionSummary
+          sx={{ backgroundColor: 'border.default' }}
+          expandIcon={<ExpandMoreIcon />}
+        >
           <Typography>{group.label}</Typography>
         </AccordionSummary>
         <AccordionDetails


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There is currently no expand icon on an accordion within the log entry creation control which makes it difficult to know if the control needs to be expanded.

## Description
<!--- Describe your changes in detail -->
- Added an expand more icon to the accordion for groups in the log entry create component.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested locally and is working well.

## Screenshots (if appropriate):
<img width="1831" height="666" alt="image" src="https://github.com/user-attachments/assets/51218b8c-e415-4353-a5c7-2816c6a99cc1" />

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.