### PR TITLE
feat(DPAV-1375) Pre-warm Users cache to support user tagging

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import './App.scss';
 import MessagingProvider from './providers/MessagingProvider';
 import ToastProvider from './providers/ToastProvider';
 import AuthContextProvider from './providers/AuthContextProvider';
+import { useUsers } from './hooks';
 
 const App = () => {
   useRegisterSW({
@@ -36,6 +37,14 @@ const App = () => {
       }),
     [queryClient]
   );
+
+  // Pre-warm users cache here
+  useUsers({
+    enabled: true,
+    staleTime: Infinity,
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
 
   return (
     <AuthContextProvider>

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -4,7 +4,7 @@
 
 // Global imports
 import { useContext } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 
 // Local imports
 import { type User } from 'common/User';
@@ -16,10 +16,16 @@ export function useAuth(): AuthContextType {
   return useContext(AuthContext) as AuthContextType;
 }
 
-export function useUsers() {
+export function useUsers(
+  options?: Omit<
+    UseQueryOptions<User[], FetchError>,
+    'queryKey' | 'queryFn'
+  >
+) {
   const { data, isLoading, isError, error } = useQuery<User[], FetchError>({
     queryKey: ['users'],
-    queryFn: () => get<User[]>('/auth/users')
+    queryFn: () => get<User[]>('/auth/users'),
+    ...options,
   });
 
   return { users: data, isLoading, isError, error };


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
Pre-warms the cache with Users. Currently Users are only cached when the user has hit the create log section of the site whilst online, if they don't reach that far and are knocked offline then the mentionable users are never cached.

## Description
One-off cache prewarming is done upon the site being hit, so if user is immediately knocked offline - then all features are available to them still.

## How Has This Been Tested?
Tested and verified locally that it runs once and does not fetch again upon every window refocus

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.