### PR TITLE
feat(DPAV-1406) "You Are Offline" banner when user is offline

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -9,6 +9,7 @@ import { Outlet } from 'react-router-dom';
 // Local imports
 import { PRINTABLE_KEY } from '../utils/constants';
 import Header from './Header';
+import { OfflineBanner } from './OfflineBanner';
 
 export default function Layout() {
   // To come from user permissions/roles
@@ -16,6 +17,7 @@ export default function Layout() {
   return (
     <div className={`App ${printable ? 'printable' : ''}`}>
       <Header />
+      <OfflineBanner /> 
       <Outlet />
     </div>
   );

--- a/frontend/src/components/OfflineBanner.tsx
+++ b/frontend/src/components/OfflineBanner.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import CloudOffIcon from '@mui/icons-material/CloudOff';
+import { Box, Typography } from '@mui/material';
+import { useIsOnline } from '../hooks/useIsOnline';
+
+export function OfflineBanner() {
+  const isOnline = useIsOnline();
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!isOnline) setVisible(true);
+    else setTimeout(() => setVisible(false), 500);
+  }, [isOnline]);
+
+  if (!visible) return null;
+
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        backgroundColor: '#938e8e',
+        color: '#fff',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 1,
+        height: 26,
+        fontSize: '0.75rem',
+        fontWeight: 600,
+        borderBottom: '1px solid #ddd',
+        zIndex: 1,
+        px: 2,
+      }}
+    >
+      <CloudOffIcon sx={{ fontSize: 16, mt: '1px' }} />
+      <Typography
+        sx={{
+          fontSize: '0.75rem',
+          fontWeight: 600,
+          lineHeight: 1,
+        }}
+      >
+    YOU ARE OFFLINE
+      </Typography>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
Displays a banner that says "You are Offline" when user is offline

## Description
As above, currently nestled under header in app stack.

## How Has This Been Tested?
Tested and verified locally across mobile and desktop view

## Screenshots (if appropriate):
<img width="619" height="53" alt="image" src="https://github.com/user-attachments/assets/265de07a-17ca-4be9-91d5-46400433788b" />
<img width="187" height="47" alt="image" src="https://github.com/user-attachments/assets/44230cfc-4cc0-406f-b29c-cbb04e64cd21" />


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.