### PR TITLE
feat(DPAV-1400) Implement pinging as backup to OnlineManager to test connectivity

### DIFF
--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -71,6 +71,8 @@ apiRouter.get('/form', formTemplate.get);
 apiRouter.post('/incident/:incidentId/form', formInstance.create);
 apiRouter.get('/incident/:incidentId/form', formInstance.get);
 
+apiRouter.head('/ping', (_, res) => res.sendStatus(200));
+
 apiRouter.use(errorsMiddleware);
 
 export default router;

--- a/deployment/k8s/backend/base/istio/allow-ingress-authorization-policy.yaml
+++ b/deployment/k8s/backend/base/istio/allow-ingress-authorization-policy.yaml
@@ -14,7 +14,7 @@ spec:
             principals : ["cluster.local/ns/istio-ingress/sa/istio-ingress"]
       to:
         - operation:
-            methods: ["GET","PATCH", "POST","PUT"]
+            methods: ["GET","PATCH", "POST","PUT", "HEAD"]
       when:
         - key: request.auth.claims[groups]
           values:

--- a/frontend/src/hooks/__tests__/useIsOnline.test.tsx
+++ b/frontend/src/hooks/__tests__/useIsOnline.test.tsx
@@ -2,82 +2,110 @@ import { renderHook, act } from '@testing-library/react';
 import { onlineManager } from '@tanstack/react-query';
 import { useIsOnline } from '../useIsOnline';
 
-// Mock onlineManager
-jest.mock('@tanstack/react-query', () => {
-  const listeners: ((online: boolean) => void)[] = [];
-  let isOnline = true;
+jest.useFakeTimers();
 
-  return {
-    onlineManager: {
-      isOnline: () => isOnline,
-      subscribe: (cb: (online: boolean) => void) => {
-        listeners.push(cb);
-        cb(isOnline);
-        return () => {
-          const index = listeners.indexOf(cb);
-          if (index > -1) listeners.splice(index, 1);
-        };
-      },
-      simulateOnlineChange: (online: boolean) => {
-        isOnline = online;
-        listeners.forEach((cb) => cb(online));
-      },
-    },
+let isOnlineState = true;
+const listeners: ((online: boolean) => void)[] = [];
+
+beforeAll(() => {
+  onlineManager.isOnline = () => isOnlineState;
+
+  onlineManager.subscribe = (cb: (online: boolean) => void) => {
+    listeners.push(cb);
+    cb(isOnlineState);
+    return () => {
+      const index = listeners.indexOf(cb);
+      if (index > -1) listeners.splice(index, 1);
+    };
+  };
+
+  onlineManager.setOnline = (value: boolean) => {
+    isOnlineState = value;
+    act(() => {
+      listeners.forEach((cb) => cb(value));
+    });
   };
 });
 
-type MockedOnlineManager = typeof onlineManager & {
-    simulateOnlineChange: (online: boolean) => void;
-  };
-  
-const mockedOnlineManager = onlineManager as MockedOnlineManager;
-
 describe('useIsOnline', () => {
-  afterEach(() => {
-    mockedOnlineManager.simulateOnlineChange(true);
+  beforeEach(() => {
+    global.fetch = jest.fn();
+    isOnlineState = true;
+    listeners.length = 0;
+
+    Object.defineProperty(navigator, 'onLine', {
+      configurable: true,
+      get: () => true,
+    });
   });
 
-  it('returns the current online state on mount', () => {
-    mockedOnlineManager.simulateOnlineChange(true);
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+  });
+
+  it('returns true if onlineManager is online', () => {
     const { result } = renderHook(() => useIsOnline());
     expect(result.current).toBe(true);
   });
 
-  it('updates when online state changes to offline', () => {
+  it('sets false if ping fails', async () => {
+    (fetch as jest.Mock).mockRejectedValue(new Error('fail'));
+
     const { result } = renderHook(() => useIsOnline());
 
-    act(() => {
-      mockedOnlineManager.simulateOnlineChange(false);
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+      await Promise.resolve();
     });
 
     expect(result.current).toBe(false);
   });
 
-  it('updates when online state changes from false to true', () => {
-    mockedOnlineManager.simulateOnlineChange(false);
+  it('sets true if ping succeeds', async () => {
+    (fetch as jest.Mock).mockResolvedValue({ ok: true });
+    isOnlineState = false;
+
     const { result } = renderHook(() => useIsOnline());
 
-    act(() => {
-      mockedOnlineManager.simulateOnlineChange(true);
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+      await Promise.resolve();
     });
 
     expect(result.current).toBe(true);
   });
 
-  it('cleans up on unmount', () => {
+  it('sets false immediately if navigator.onLine is false', async () => {
+    Object.defineProperty(navigator, 'onLine', {
+      configurable: true,
+      get: () => false,
+    });
+
+    const { result } = renderHook(() => useIsOnline());
+
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it('cleans up interval and unsubscribes on unmount', () => {
+    const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
     const unsubscribeMock = jest.fn();
 
-    const spySubscribe = jest
-      .spyOn(onlineManager, 'subscribe')
-      .mockImplementation((cb) => {
-        cb(true);
-        return unsubscribeMock;
-      });
+    // Override onlineManager.subscribe just for this test
+    const originalSubscribe = onlineManager.subscribe;
+    onlineManager.subscribe = () => unsubscribeMock;
 
     const { unmount } = renderHook(() => useIsOnline());
     unmount();
 
+    expect(clearIntervalSpy).toHaveBeenCalled();
     expect(unsubscribeMock).toHaveBeenCalled();
-    spySubscribe.mockRestore();
+
+    // Restore original
+    onlineManager.subscribe = originalSubscribe;
   });
 });

--- a/frontend/src/hooks/useIsOnline.ts
+++ b/frontend/src/hooks/useIsOnline.ts
@@ -1,12 +1,39 @@
 import { useEffect, useState } from 'react';
 import { onlineManager } from '@tanstack/react-query';
 
+const PING_INTERVAL_MS = 2500; // polls every 2.5s
+const PING_URL = '/api/ping'; 
+
 export function useIsOnline(): boolean {
   const [isOnline, setIsOnline] = useState(onlineManager.isOnline());
 
   useEffect(() => {
     const unsubscribe = onlineManager.subscribe(setIsOnline);
-    return () => unsubscribe();
+
+    const ping = async () => {
+      if (!navigator.onLine) {
+        onlineManager.setOnline(false);
+        return;
+      }
+
+      try {
+        const response = await fetch(PING_URL, {
+          method: 'HEAD',
+          cache: 'no-store',
+        });
+        onlineManager.setOnline(response.ok);
+      } catch {
+        onlineManager.setOnline(false);
+      }
+    };
+
+    ping();
+    const intervalId = setInterval(ping, PING_INTERVAL_MS);
+
+    return () => {
+      clearInterval(intervalId);
+      unsubscribe();
+    };
   }, []);
 
   return isOnline;


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
OnlineManager.onLine not a consistent answer to testing connectivity, shows as connected on desktop even with airplane mode on and wifi off.

## Description
Tests OnlineManager.onLine -> if true, then it will poll a HEAD endpoint on the API every 2.5s
                                              -> if false, then it will not poll until the state changes back to true

if OnlineManager.onLine is true, but ping fails then user is "offline".
if OnlineManager.onLine is false, then user is "offline"
if OnlineManager.onLine is true, and ping succeeds, then user is "online".

## How Has This Been Tested?
Tested and verified locally using VBox network tools and simply not running the backend.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.