### PR TITLE
feat(DPAV-1432) Home page design feedback implemented

### DIFF
--- a/frontend/src/components/Widgets/AlertsWidget.tsx
+++ b/frontend/src/components/Widgets/AlertsWidget.tsx
@@ -4,7 +4,7 @@
 
 import { useNavigate } from 'react-router-dom';
 
-import { Typography } from '@mui/material';
+import { Button, Typography } from '@mui/material';
 import WidgetBase from './WidgetBase';
 import { useNotifications } from '../../hooks/useNotifications';
 
@@ -12,16 +12,46 @@ import { useNotifications } from '../../hooks/useNotifications';
 const AlertsWidget = () => {
   const navigate = useNavigate();
   const { notifications } = useNotifications();
-  const unreadCount = notifications?.filter((n) => !n.read).length;
-  const onNavigate = () => navigate('/notifications');
+  const unreadCount = notifications?.filter((n) => !n.read).length ?? 0;
+
+  const onNavigateAlertsHeader = () => navigate('/notifications');
+  const onNavigateUnread = () => navigate('/notifications#unread')
 
   return (
-    <WidgetBase title="Alerts" onAction={onNavigate} showArrow>
+    <WidgetBase title="Alerts" onAction={onNavigateAlertsHeader} showArrow>
       <Typography variant="body2">
-        You have <Typography component="span" color="primary" fontWeight="bold" variant="body2">{unreadCount} unread</Typography> notifications
+        You have{' '}
+        {unreadCount > 0 ? (
+          <Button
+            onClick={onNavigateUnread}
+            variant="text"
+            color="primary"
+            sx={{
+              padding: 0,
+              minWidth: 0,
+              textTransform: 'none',
+              fontWeight: 'bold',
+              fontSize: 'inherit',
+              verticalAlign: 'baseline',
+            }}
+            aria-label="View unread notifications"
+          >
+            {unreadCount} unread
+          </Button>
+        ) : (
+          <Typography
+            component="span"
+            fontWeight="bold"
+            variant="body2"
+            color="text.primary"
+          >
+            {unreadCount} unread
+          </Typography>
+        )}{' '}
+        notifications
       </Typography>
     </WidgetBase>
   );
-}
+};
 
 export default AlertsWidget;

--- a/frontend/src/components/Widgets/TaskWidget.tsx
+++ b/frontend/src/components/Widgets/TaskWidget.tsx
@@ -24,7 +24,14 @@ const TasksWidget = () => {
             onClick={onClick}
             color="primary"
             variant="text"
-            sx={{ fontSize: '1.5rem', fontWeight: 500 }}
+            sx={{
+              fontSize: '1.5rem',
+              fontWeight: 500,
+              padding: 0,
+              minWidth: 0,
+              minHeight: 0,
+              lineHeight: 1.2,
+            }}
           >
             {count}
           </Button>

--- a/frontend/src/components/Widgets/TaskWidget.tsx
+++ b/frontend/src/components/Widgets/TaskWidget.tsx
@@ -2,48 +2,85 @@
 // © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 // and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, Button } from '@mui/material';
 import WidgetBase from './WidgetBase';
 import { logInfo } from '../../utils/logger';
 
 const TasksWidget = () => {
   const toDoCount = 0;
   const inProgressCount = 0;
-  const onNavigate = () => logInfo('Clicked tasks');
+
+  const onNavigateToDo = () => logInfo('Clicked To do');
+  const onNavigateInProgress = () => logInfo('Clicked In progress');
+  const onNavigateTasksHeader = () => logInfo('Clicked tasks header');
+
+  const renderCount = (count: number, onClick: () => void) => {
+    const isActive = count > 0;
+  
+    return (
+      <Box flex={1} textAlign="center">
+        {isActive ? (
+          <Button
+            onClick={onClick}
+            color="primary"
+            variant="text"
+            sx={{ fontSize: '1.5rem', fontWeight: 500 }}
+          >
+            {count}
+          </Button>
+        ) : (
+          <Typography variant="h5">{count}</Typography>
+        )}
+      </Box>
+    );
+  };
+  
+  const renderLabel = (count: number, label: string, onClick: () => void) => {
+    const isActive = count > 0;
+  
+    return (
+      <Box flex={1} textAlign="center">
+        {isActive ? (
+          <Button
+            onClick={onClick}
+            color="primary"
+            variant="text"
+            sx={{ textTransform: 'none', padding: 0, minWidth: 0 }}
+            aria-label={`View ${label} tasks`}
+          >
+            <Typography variant="body2" color="primary">{label}</Typography>
+          </Button>
+        ) : (
+          <Typography variant="body2">{label}</Typography>
+        )}
+      </Box>
+    );
+  };
 
   return (
-    <WidgetBase title="Your tasks" onAction={onNavigate} showArrow>
+    <WidgetBase title="Your tasks" onAction={onNavigateTasksHeader} showArrow>
       <Box display="flex" flexDirection="column" alignItems="stretch">
-
         <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
-          <Box flex={1} textAlign="center">
-            <Typography variant="h5" color="primary">{toDoCount}</Typography>
-          </Box>
-          <Box flex={1} textAlign="center">
-            <Typography variant="h5">{inProgressCount}</Typography>
-          </Box>
+          {renderCount(toDoCount, onNavigateToDo)}
+          {renderCount(inProgressCount, onNavigateInProgress)}
           <Box flex={1} textAlign="center">
             <Typography variant="h5" sx={{ visibility: 'hidden' }}>0</Typography>
           </Box>
         </Box>
 
         <Box display="flex" justifyContent="space-between" alignItems="flex-start">
-          <Box flex={1} textAlign="center">
-            <Typography variant="body2" color="primary">To do</Typography>
-          </Box>
-          <Box flex={1} textAlign="center">
-            <Typography variant="body2">In progress</Typography>
-          </Box>
+          {renderLabel(toDoCount, 'To do', onNavigateToDo)}
+          {renderLabel(inProgressCount, 'In progress', onNavigateInProgress)}
           <Box flex={1} textAlign="center">
             <Box>
-              <Typography variant="body2" color="lightgrey">Not started</Typography>
+              <Typography variant="body2" color="lightgrey">Overdue</Typography>
               <Typography variant="body2" color="lightgrey">(coming soon)</Typography>
             </Box>
           </Box>
         </Box>
       </Box>
     </WidgetBase>
-  )
+  );
 };
 
 export default TasksWidget;

--- a/frontend/src/components/Widgets/WidgetBase.tsx
+++ b/frontend/src/components/Widgets/WidgetBase.tsx
@@ -12,13 +12,30 @@ type WidgetBaseProps = PropsWithChildren & {
   showArrow?: boolean;
 }
 
-const WidgetBase = ({ title, onAction = undefined, showArrow = false, children } : WidgetBaseProps) => (
+const WidgetBase = ({ title, onAction = undefined, showArrow = false, children }: WidgetBaseProps) => (
   <Card variant="outlined" sx={{ borderRadius: 2 }}>
     <CardContent>
-      <Box display="flex" justifyContent="space-between" alignItems="center" mb={3}>
+      <Box
+        display="flex"
+        justifyContent="space-between"
+        alignItems="center"
+        mb={3}
+        onClick={onAction}
+        sx={{
+          cursor: onAction ? 'pointer' : 'default',
+          userSelect: 'none'
+        }}
+      >
         <Typography variant="h5">{title}</Typography>
         {showArrow && onAction && (
-          <IconButton onClick={onAction} size="small">
+          <IconButton
+            color="primary"
+            onClick={(e) => {
+              e.stopPropagation();
+              onAction();
+            }}
+            size="small"
+          >
             <ArrowForwardIcon fontSize="small" />
           </IconButton>
         )}

--- a/frontend/src/pages/Notifications.tsx
+++ b/frontend/src/pages/Notifications.tsx
@@ -6,8 +6,8 @@ import NotificationsIcon from '@mui/icons-material/Notifications';
 import NotificationsNoneOutlinedIcon from '@mui/icons-material/NotificationsNoneOutlined';
 import { Box, List, ListItem, Tab, Tabs, Typography } from '@mui/material';
 import { type Notification } from 'common/Notification';
-import React, { useState, useMemo, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import getHandler from '../components/Notifications/handlers';
 import { useNotifications, useReadNotification } from '../hooks';
 import { Format } from '../utils';
@@ -72,14 +72,22 @@ function NotificationSpacer() {
 }
 
 export default function Notifications() {
-  const [tabValue, setTabValue] = useState(0);
+  const location = useLocation();
   const { notifications } = useNotifications();
   const readNotification = useReadNotification();
   const navigate = useNavigate();
 
+  const [tabValue, setTabValue] = useState(0);
+
   const handleTabChange = (_: React.SyntheticEvent, newValue: number) => {
     setTabValue(newValue);
   };
+
+  useEffect(() => {
+    if (location.hash === '#unread') {
+      setTabValue(1); // Unread tab index
+    }
+  }, [location.hash]);
 
   const notificationsArray = useMemo(() => notifications ?? [], [notifications]);
   const unreadNotifications = useMemo(() => notificationsArray.filter((n) => !n.read), [notificationsArray]);


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
- Updates home page per design review feedback

## Description
- Full header of each widget navigates to relevant page (if action is specified)
- Tasks widget - To Do and In Progress counts and labels hyperlinked and displayed in blue if count is > 0, otherwise non-linked and shown in black
- Alerts widget - (count) unread notifications hyperlinked and displayed in blue if count is > 0, otherwise non-linked and shown in black
- unread notifications link now links directly to the Unread tab in notifications
- Tasks widget not wired in due to Tasks work pending
- No Add New button added yet since that work is pending

## How Has This Been Tested?
Tested and verified locally

## Screenshots (if appropriate):
<img width="238" height="362" alt="image" src="https://github.com/user-attachments/assets/c2ef9fe5-93ef-42ce-98f4-dd369e2d1962" />
<img width="246" height="361" alt="image" src="https://github.com/user-attachments/assets/998351c7-050c-428b-aeb7-c3ef8e47761b" />
<img width="238" height="355" alt="image" src="https://github.com/user-attachments/assets/6a7222fe-2f5b-44b3-a809-c5883f1bed70" />


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.