### PR TITLE
feat(DPAV-1436) Incident logbook screen redesign

### DIFF
--- a/frontend/src/components/PageTitle.tsx
+++ b/frontend/src/components/PageTitle.tsx
@@ -24,7 +24,8 @@ const PageTitle = ({ title, subtitle = undefined, stage = undefined, children }:
     flexWrap="wrap"
     alignItems="center"
     justifyContent="space-between"
-    gap="1rem"
+    columnGap="1rem"
+    rowGap="0.5rem"
     width="100%"
   >
     <Box display="flex" flexDirection="column" gap={1}>

--- a/frontend/src/components/Stage/StageMini.tsx
+++ b/frontend/src/components/Stage/StageMini.tsx
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+// and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
+
+import { Box } from '@mui/material';
+
+const StageMini = ({
+  stage,
+  size = 12
+}: {
+  stage: 'Monitoring' | 'Response' | 'Recovery' | 'Closed';
+  size?: number;
+}) => {
+  const color = stage.toLowerCase();
+  return (
+    <Box
+      sx={{
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        backgroundColor: `stage.${color}.secondary`,
+        border: 1,
+        borderColor: `stage.${color}.primary`,
+        display: 'inline-block'
+      }}
+    />
+  );
+};
+
+export default StageMini;

--- a/frontend/src/pages/Logbook.tsx
+++ b/frontend/src/pages/Logbook.tsx
@@ -4,8 +4,9 @@
 
 import { MouseEvent, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { Box, Button, Typography } from '@mui/material';
+import { Box, Button, IconButton, Typography } from '@mui/material';
 import AddCircleIcon from '@mui/icons-material/AddCircle';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
 import { v4 as uuidV4 } from 'uuid';
 
 import { type Mentionable, type MentionableType } from 'common/Mentionable';
@@ -32,6 +33,7 @@ import { buildLogFilters, logSort } from '../components/SortFilter/schemas/log-s
 import { type QueryState } from '../components/SortFilter/filter-types';
 import { useFormTemplates } from '../hooks/Forms/useFormTemplates';
 import { getFromAndToFromTimeSelection } from '../components/SortFilter/filter-utils';
+import StageMini from '../components/Stage/StageMini';
 
 const Logbook = () => {
   const { incidentId } = useParams();
@@ -268,24 +270,82 @@ const Logbook = () => {
 
   return (
     <PageWrapper>
-      <PageTitle
-        title={incident?.type ? Format.incident.type(incident?.type) : ''}
-        subtitle={incident?.name ?? ''}
-        stage={incident?.stage}
-      >
-        <Box display="flex" flexDirection="row" justifyContent="space-between">
-          {!adding && (
+      <PageTitle title={incident?.name ?? ''}>
+        <Box sx={{ mt: -2, width: '100%' }}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+              width: '100%',
+              px: 0.5,
+            }}
+          >
+            <StageMini stage={incident?.stage ?? 'Monitoring'} size={12} />
+
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Typography
+                variant="body2"
+                color="grey"
+                sx={{
+                  overflowX: 'auto',
+                  whiteSpace: 'nowrap',
+                  pr: 2,
+                  maskImage: 'linear-gradient(to right, black 80%, transparent 100%)',
+                  WebkitMaskImage: 'linear-gradient(to right, black 80%, transparent 100%)',
+                  scrollbarWidth: 'none',
+                  msOverflowStyle: 'none',
+                  '&::-webkit-scrollbar': {
+                    display: 'none',
+                  },
+                }}
+                aria-label="Incident type"
+                role="region"
+              >
+                {incident?.type ? Format.incident.type(incident.type).toUpperCase() : ''}
+              </Typography>
+            </Box>
+
+            <IconButton
+              aria-label="More options"
+              onClick={() => navigate(`/incident/${incident?.id}`)}
+            >
+              <MoreVertIcon />
+            </IconButton>
+          </Box>
+        </Box>
+  
+        {!adding && (
+          <Box
+            display="flex"
+            flexDirection="row"
+            alignItems="center"
+            gap={2}
+            flexWrap="wrap"
+            width="100%"
+            displayPrint="none"
+          >
             <Button
               type="button"
               variant="contained"
               size={isMobile ? 'medium' : 'large'}
               startIcon={<AddCircleIcon />}
               onClick={onAddEntryClick}
+              sx={{ flex: 1 }}
             >
-              Add log entry
+              Add new
             </Button>
-          )}
-        </Box>
+
+            <Button
+              type="button"
+              variant="contained"
+              onClick={handleOpenFilters}
+              sx={{ flex: 1 }}
+            >
+              Sort & Filter
+            </Button>
+          </Box>
+        )}
       </PageTitle>
 
       {adding && (
@@ -297,50 +357,31 @@ const Logbook = () => {
         />
       )}
 
-      <Box display="flex" flexDirection="column" width="100%">
-        {logEntries && logEntries.length > 0 ? (
-          <>
-            <Box
-              display="flex"
-              flexDirection="row"
-              justifyContent="space-between"
-              flexWrap="wrap"
-              width="100%"
-              mb="1.6rem"
-              gap={1}
-              displayPrint="none"
-            >
-              <Box display="flex" flexDirection="row" flexGrow={1} gap={2}>
-                <Button
-                  type="button"
-                  variant="contained"
-                  onClick={handleOpenFilters}
-                >
-                  Sort & Filter
-                </Button>
-              </Box>
+      {!adding && (
+        <Box display="flex" flexDirection="column" width="100%">
+          {(!logEntries || logEntries.length === 0) && (
+            <Box p={2} bgcolor="background.default">
+              <Typography variant="h6">No logs found.</Typography>
+              <Typography mt={1}>There are currently no log entries.</Typography>
             </Box>
-
-            {visibleEntries.length > 0 ? (
-              <EntryList
-                entries={visibleEntries}
-                onContentClick={onContentClick}
-                onMentionClick={onMentionClick}
-              />
-            ) : (
-              <Box p={2} bgcolor="background.default">
-                <Typography variant="h6">No results found.</Typography>
-                <Typography mt={1}>Try adjusting your filters.</Typography>
-              </Box>
-            )}
-          </>
-        ) : (
-          <Box p={2} bgcolor="background.default">
-            <Typography variant="h6">No logs found.</Typography>
-            <Typography mt={1}>There are currently no log entries.</Typography>
-          </Box>
-        )}
-      </Box>
+          )}
+      
+          {logEntries && logEntries.length > 0 && visibleEntries.length === 0 && (
+            <Box p={2} bgcolor="background.default">
+              <Typography variant="h6">No results found.</Typography>
+              <Typography mt={1}>Try adjusting your filters.</Typography>
+            </Box>
+          )}
+      
+          {logEntries && logEntries.length > 0 && visibleEntries.length > 0 && (
+            <EntryList
+              entries={visibleEntries}
+              onContentClick={onContentClick}
+              onMentionClick={onMentionClick}
+            />
+          )}
+        </Box>
+      )}
 
       <SortAndFilter
         open={filtersOpen}

--- a/frontend/src/pages/Logbook.tsx
+++ b/frontend/src/pages/Logbook.tsx
@@ -290,6 +290,7 @@ const Logbook = () => {
 
             <Box sx={{ flex: 1, minWidth: 0 }}>
               <Typography
+                component="section"
                 variant="body2"
                 color="grey"
                 sx={{
@@ -305,7 +306,6 @@ const Logbook = () => {
                   },
                 }}
                 aria-label="Incident type"
-                role="region"
               >
                 {incident?.type ? Format.incident.type(incident.type).toUpperCase() : ''}
               </Typography>


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
Redesigns Incident logbook screen per agreed designs

## Description
 - Moves Incident name to title and type to subtitle
 - Subtitle consists of mini-Stage chip (coloured circle) with scrollable Incident Type text and 3 dots button
 - 3 dots button navigates immediately to Incident Overview page
 - Add Log Entry button text modified to Add New

## How Has This Been Tested?
Tested and verified locally

## Screenshots (if appropriate):
<img width="222" height="203" alt="image" src="https://github.com/user-attachments/assets/bba43161-a143-4ac3-bef1-8b6f72ae12e9" />


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.