### PR TITLE
feat(DPAV-1511): Implement tasks page

### DIFF
--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -62,7 +62,8 @@ apiRouter.get('/searchLocation', osMaps.searchLocation);
 apiRouter.get('/notifications', notifications.get);
 apiRouter.put('/notifications/:id', notifications.markRead);
 
-apiRouter.get('/incident/:incidentId/tasks', task.get);
+apiRouter.get('/tasks', task.get);
+apiRouter.get('/incident/:incidentId/tasks', task.getForIncidentId);
 apiRouter.post('/incident/:incidentId/tasks', task.create);
 apiRouter.patch('/task/:taskId/status', task.changeStatus);
 apiRouter.patch('/task/:taskId/assignee', task.changeAssignee);

--- a/backend/src/services/task/get.ts
+++ b/backend/src/services/task/get.ts
@@ -4,7 +4,7 @@
 
 import { Request, Response } from 'express';
 import { Task, TaskStatus } from 'common/Task';
-import { tasks } from '../logEntry/utils/select/tasks';
+import { tasks } from './utils/select/tasks';
 import { type ResultRow } from '../../ia';
 import { nodeValue } from '../../rdfutil';
 
@@ -12,40 +12,36 @@ function removePrefix(uri: string): string {
   return uri.split('#').pop() || uri.split('/').pop() || uri;
 }
 
-async function parseTasks(results: ResultRow[], incidentId: string): Promise<Task[]> {
-  return results.map((result) => {
-    const taskId = nodeValue(result.taskId.value);
-    const assigneeNode = result.assignee?.value;
-    const assigneeUsername = assigneeNode ? nodeValue(assigneeNode) : undefined;
+function mapResultToTask(result: ResultRow): Task {
+  const taskId = nodeValue(result.taskId.value);
+  const incidentId = nodeValue(result.incidentId.value);
+  const assigneeNode = result.assignee?.value;
+  const assigneeUsername = assigneeNode ? nodeValue(assigneeNode) : undefined;
 
-    const authorNode = result.author?.value;
-    const authorUsername = authorNode ? nodeValue(authorNode) : undefined;
+  const authorNode = result.author?.value;
+  const authorUsername = authorNode ? nodeValue(authorNode) : undefined;
 
-    const task: Task = {
-      id: taskId,
-      name: result.taskName.value,
-      description: result.description.value,
-      incidentId,
-      author: {
-        username: authorUsername ?? 'unknown',
-        displayName: result.authorName?.value ?? 'Unknown User'
-      },
-      assignee: {
-        username: assigneeUsername ?? result.assigneeName?.value ?? 'unknown',
-        displayName: result.assigneeName?.value ?? 'Unknown User'
-      },
-      status: removePrefix(result.taskStatus?.value || 'ToDo') as TaskStatus,
-      sequence: result.sequence.value,
-      createdAt: result.createdAt.value
-    };
-
-    return task;
-  });
+  return {
+    id: taskId,
+    name: result.taskName.value,
+    description: result.description.value,
+    incidentId,
+    author: {
+      username: authorUsername ?? 'unknown',
+      displayName: result.authorName?.value ?? 'Unknown User'
+    },
+    assignee: {
+      username: assigneeUsername ?? result.assigneeName?.value ?? 'unknown',
+      displayName: result.assigneeName?.value ?? 'Unknown User'
+    },
+    status: removePrefix(result.taskStatus?.value || 'ToDo') as TaskStatus,
+    sequence: result.sequence.value,
+    createdAt: result.createdAt.value
+  };
 }
 
-export async function get(req: Request, res: Response) {
+export async function getForIncidentId(req: Request, res: Response) {
   const { incidentId } = req.params;
-
   if (!incidentId) {
     res.status(400).end();
     return;
@@ -53,8 +49,18 @@ export async function get(req: Request, res: Response) {
 
   try {
     const taskResults = await tasks(incidentId);
-    const tasksArray = await parseTasks(taskResults, incidentId);
+    const tasksArray = taskResults.map((r) => mapResultToTask(r));
+    res.json(tasksArray);
+  } catch (error) {
+    console.error('Error fetching tasks:', error);
+    res.status(500).json({ error: 'Failed to fetch tasks' });
+  }
+}
 
+export async function get(_req: Request, res: Response) {
+  try {
+    const taskResults = await tasks();
+    const tasksArray = taskResults.map((r) => mapResultToTask(r));
     res.json(tasksArray);
   } catch (error) {
     console.error('Error fetching tasks:', error);

--- a/backend/src/services/task/index.ts
+++ b/backend/src/services/task/index.ts
@@ -5,4 +5,4 @@
 export { changeStatus } from './changeStatus';
 export { changeAssignee } from './changeAssignee';
 export { create } from './create';
-export { get } from './get';
+export { get, getForIncidentId } from './get';

--- a/backend/src/services/task/utils/select/tasks.ts
+++ b/backend/src/services/task/utils/select/tasks.ts
@@ -11,7 +11,7 @@ import { TaskStatus } from 'common/Task';
 import { select } from '../../../../ia';
 import { ns } from '../../../../rdfutil';
 
-export function tasks(incidentId: string) {
+export function tasks(incidentId?: string) {
   const statusNotExistsFilter = new TriplePattern('?x', ns.ies.isEndOf, '?statusNode');
   const assigneeNotExistsFilter = new TriplePattern('?x', ns.ies.isEndOf, '?assigneeNode');
 
@@ -19,9 +19,15 @@ export function tasks(incidentId: string) {
     .map((literal) => `<${ns.lisa(literal.value).value}>`)
     .join(' ');
 
+  const incidentClauses: unknown[] = [
+    ['?incidentId', ns.lisa.hasTask, '?taskId'],
+    ...(incidentId ? [`FILTER(?incidentId = <${ns.data(incidentId).value}>)`] : [])
+  ];
+
   return select({
     clause: [
-      [ns.data(incidentId), ns.lisa.hasTask, '?taskId'],
+      ...incidentClauses,
+      ['?incidentId', ns.ies.hasName, '?incidentName'],
       ['?taskId', ns.ies.hasName, '?taskName'],
       ['?taskId', ns.lisa.hasDescription, '?description'],
       ['?taskId', ns.lisa.hasSequence, '?sequence'],
@@ -56,3 +62,5 @@ export function tasks(incidentId: string) {
     orderBy: [['?createdAt', 'DESC']]
   });
 }
+
+

--- a/frontend/src/components/AppWrapper.tsx
+++ b/frontend/src/components/AppWrapper.tsx
@@ -18,6 +18,7 @@ import Location from '../pages/Location';
 import Logbook from '../pages/Logbook';
 import Notifications from '../pages/Notifications';
 import Overview from '../pages/Overview';
+import IncidentTasks from '../pages/IncidentTasks';
 import Settings from '../pages/Settings';
 import Tasks from '../pages/Tasks';
 import Layout from './Layout';
@@ -36,7 +37,8 @@ const AppWrapper = () => {
         { path: 'createlog', element: <CreateLog /> },
         { path: 'incident/:incidentId', element: <Overview /> },
         { path: 'logbook/:incidentId', element: <Logbook /> },
-        { path: 'tasks/:incidentId', element: <Tasks /> },
+        { path: 'tasks', element: <Tasks /> },
+        { path: 'tasks/:incidentId', element: <IncidentTasks /> },
         { path: 'forms/:incidentId', element: <LogForms /> },
         { path: 'location/:incidentId', element: <Location /> },
         { path: 'files/:incidentId', element: <Files /> },

--- a/frontend/src/components/DataList.tsx
+++ b/frontend/src/components/DataList.tsx
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+// and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
+
+import React from 'react';
+import { Box, List, ListItem, Typography } from '@mui/material';
+
+export type ListRow = {
+  key: string;
+  title: React.ReactNode;
+  content?: React.ReactNode;
+  footer?: React.ReactNode;
+  metaRight?: React.ReactNode;
+  titleDot?: React.ReactNode;
+  emphasizeTitle?: boolean;
+  onClick?: () => void;
+};
+
+type DataListProps = {
+  items: ReadonlyArray<ListRow>;
+};
+
+export default function DataList({ items }: Readonly<DataListProps>) {
+  const hasAnyDots = items.some((item) => item.titleDot !== undefined);
+
+  return (
+    <List sx={{ display: 'flex', flexDirection: 'column', padding: 0, gap: '1px' }}>
+      {items.map((item) => (
+        <ListItem
+          key={item.key}
+          sx={{
+            padding: 2,
+            cursor: item.onClick ? 'pointer' : 'default',
+            backgroundColor: 'background.paper',
+            '&:hover': item.onClick ? { backgroundColor: 'action.hover' } : undefined
+          }}
+          onClick={item.onClick}
+        >
+          <Box sx={{ width: '100%', display: 'flex', gap: hasAnyDots ? 2 : 0 }} data-testid="list-item-container">
+            {hasAnyDots && (
+              <Box sx={{ width: 14, flexShrink: 0 }}>
+                <Box sx={{ height: '1.5rem', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                  {item.titleDot}
+                </Box>
+              </Box>
+            )}
+
+            <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 1 }}>
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <Typography
+                  variant="body1"
+                  color="primary"
+                  sx={{ fontWeight: item.emphasizeTitle ? 'bold' : 'normal' }}
+                >
+                  {item.title}
+                </Typography>
+                <Typography color="text.secondary">{item.metaRight}</Typography>
+              </Box>
+              {item.content && <Box>{item.content}</Box>}
+              {item.footer && (
+                <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.75rem', fontWeight: 500 }}>
+                  {item.footer}
+                </Typography>
+              )}
+            </Box>
+          </Box>
+        </ListItem>
+      ))}
+    </List>
+  );
+}

--- a/frontend/src/components/Notifications/handlers.tsx
+++ b/frontend/src/components/Notifications/handlers.tsx
@@ -62,7 +62,7 @@ function assignedTask(notification: Notification, navigate: NavigateFunction): H
     footer: `INCIDENT: ${incidentTitle}`,
     clickHandler: (item) => {
       if (TaskAssignedNotification.guard(item)) {
-        navigate(`/tasks/${item.task.incidentId}#${item.task.id}`); // TODO: might need to add the Task-{id}
+        navigate(`/tasks/${item.task.incidentId}#${item.task.id}`);
       }
     }
   };

--- a/frontend/src/components/SortFilter/filter-utils.ts
+++ b/frontend/src/components/SortFilter/filter-utils.ts
@@ -2,7 +2,7 @@
 // © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 // and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
-import { FilterTree, GroupNode, OptionLeaf } from "./filter-types";
+import { FilterTree, GroupNode, OptionLeaf, QueryState } from "./filter-types";
 
 const resolveTimeRange = (preset: string | undefined): { from?: number; to?: number } => {
   const now = new Date();
@@ -93,3 +93,31 @@ export const applyImpliedSelections = (
   };
 };
   
+
+export const countActive = (values: QueryState['values']) => 
+  Object.entries(values)
+    .filter(([key, v]) => {
+      if (key === 'sort') return false;
+      if (Array.isArray(v)) return v.length > 0;
+      if (v == null || v === '') return false;
+      if (typeof v === 'object') return Object.values(v).some(Boolean);
+      return true;
+    })
+    .map(([key]) => key.split('.')[0])
+    .filter((v, i, arr) => arr.indexOf(v) === i)
+    .length;
+
+
+export const countActiveForGroup = (values: QueryState['values'], groupId: string): number => 
+  Object.entries(values)
+    .filter(([key, v]) => {
+      // Check if this key belongs to the group
+      const keyGroup = key.split('.')[0];
+      if (keyGroup !== groupId) return false;
+      
+      if (Array.isArray(v)) return v.length > 0;
+      if (v == null || v === '') return false;
+      if (typeof v === 'object') return Object.values(v).some(Boolean);
+      return true;
+    })
+    .length;

--- a/frontend/src/components/SortFilter/schemas/task-schema.ts
+++ b/frontend/src/components/SortFilter/schemas/task-schema.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+// and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
+
+import { FilterTree, SortOption } from '../filter-types';
+import { makeGroup, makeOptions } from './schema-utils';
+
+export const taskSort: SortOption[] = [
+  { id: 'name_asc', label: 'Task name (A-Z)' },
+  { id: 'name_desc', label: 'Task name (Z-A)' },
+  { id: 'author_asc', label: 'Created by (A-Z)' },
+  { id: 'author_desc', label: 'Created by (Z-A)' },
+  { id: 'date_asc', label: 'Date created (oldest - newest)' },
+  { id: 'date_desc', label: 'Date created (newest - oldest)' }
+];
+
+export const buildTaskFilters = (
+  authors: { username: string; displayName: string }[] = [],
+  assignees: { username: string; displayName: string }[] = [],
+  incidents: { id: string; name: string }[] = []
+): FilterTree => ({
+  title: 'Sort & Filter',
+  items: [
+    makeGroup('sort', 'Sort by', 'single', makeOptions(taskSort)),
+    makeGroup(
+      'author',
+      'Author',
+      'multi',
+      makeOptions(
+        authors.map((user) => ({
+          id: user.username,
+          label: user.displayName
+        }))
+      )
+    ),
+    makeGroup(
+      'assignee',
+      'Assignee',
+      'multi',
+      makeOptions(
+        assignees.map((user) => ({
+          id: user.username,
+          label: user.displayName
+        }))
+      )
+    ),
+    makeGroup(
+      'incident',
+      'Incident',
+      'multi',
+      makeOptions(
+        incidents.map((incident) => ({
+          id: incident.id,
+          label: incident.name
+        }))
+      )
+    ),
+    makeGroup(
+      'status',
+      'Status',
+      'multi',
+      makeOptions([
+        { id: 'ToDo', label: 'To do' },
+        { id: 'InProgress', label: 'In progress' },
+        { id: 'Done', label: 'Done' }
+      ])
+    )
+  ]
+});

--- a/frontend/src/components/__tests__/DataList.test.tsx
+++ b/frontend/src/components/__tests__/DataList.test.tsx
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+// © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+// and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import DataList, { type ListRow } from '../DataList';
+
+describe('DataList component', () => {
+  const mockItems: ListRow[] = [
+    {
+      key: 'item1',
+      title: 'First Item',
+      content: 'This is the content for the first item',
+      footer: 'Footer text',
+      metaRight: 'Meta info'
+    },
+    {
+      key: 'item2',
+      title: 'Second Item',
+      emphasizeTitle: true,
+      titleDot: <div>•</div>,
+      onClick: jest.fn()
+    }
+  ];
+
+  it('renders list items correctly', () => {
+    render(<DataList items={mockItems} />);
+
+    expect(screen.getByText('First Item')).toBeInTheDocument();
+    expect(screen.getByText('Second Item')).toBeInTheDocument();
+    expect(screen.getByText('This is the content for the first item')).toBeInTheDocument();
+    expect(screen.getByText('Footer text')).toBeInTheDocument();
+    expect(screen.getByText('Meta info')).toBeInTheDocument();
+  });
+
+  it('handles click events', () => {
+    const mockOnClick = jest.fn();
+    const clickableItems: ListRow[] = [
+      {
+        key: 'clickable',
+        title: 'Clickable Item',
+        onClick: mockOnClick
+      }
+    ];
+
+    render(<DataList items={clickableItems} />);
+
+    const listItem = screen.getByRole('listitem');
+    fireEvent.click(listItem);
+
+    expect(mockOnClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders title dots when present', () => {
+    const itemsWithDots: ListRow[] = [
+      {
+        key: 'with-dot',
+        title: 'Item with dot',
+        titleDot: <span data-testid="dot">•</span>
+      },
+      {
+        key: 'without-dot',
+        title: 'Item without dot'
+      }
+    ];
+
+    render(<DataList items={itemsWithDots} />);
+
+    expect(screen.getByTestId('dot')).toBeInTheDocument();
+  });
+
+  it('emphasizes titles when specified', () => {
+    const itemsWithEmphasis: ListRow[] = [
+      {
+        key: 'emphasized',
+        title: 'Emphasized Title',
+        emphasizeTitle: true
+      }
+    ];
+
+    render(<DataList items={itemsWithEmphasis} />);
+
+    const title = screen.getByText('Emphasized Title');
+    expect(title).toHaveStyle('font-weight: 700');
+  });
+
+  it('renders empty list when no items provided', () => {
+    render(<DataList items={[]} />);
+
+    const list = screen.getByRole('list');
+    expect(list).toBeInTheDocument();
+    expect(list).toBeEmptyDOMElement();
+  });
+
+  it('applies cursor pointer style for clickable items', () => {
+    const clickableItems: ListRow[] = [
+      {
+        key: 'clickable',
+        title: 'Clickable Item',
+        onClick: jest.fn()
+      }
+    ];
+
+    render(<DataList items={clickableItems} />);
+
+    const listItem = screen.getByRole('listitem');
+    expect(listItem).toHaveStyle('cursor: pointer');
+  });
+
+  it('applies default cursor for non-clickable items', () => {
+    const nonClickableItems: ListRow[] = [
+      {
+        key: 'non-clickable',
+        title: 'Non-clickable Item'
+      }
+    ];
+
+    render(<DataList items={nonClickableItems} />);
+
+    const listItem = screen.getByRole('listitem');
+    expect(listItem).toHaveStyle('cursor: default');
+  });
+
+  it('applies correct gap when no items have dots', () => {
+    const itemsWithoutDots: ListRow[] = [
+      {
+        key: 'item1',
+        title: 'Item One'
+      },
+      {
+        key: 'item2',
+        title: 'Item Two'
+      }
+    ];
+
+    render(<DataList items={itemsWithoutDots} />);
+
+    const containerBoxes = screen.getAllByTestId('list-item-container');
+    expect(containerBoxes[0]).toHaveStyle('gap: 0px');
+  });
+});

--- a/frontend/src/hooks/__tests__/useTasks.test.tsx
+++ b/frontend/src/hooks/__tests__/useTasks.test.tsx
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+// and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
+
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useTasks, useAllTasks } from '../useTasks';
+import { get } from '../../api';
+
+jest.mock('../../api');
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false
+      }
+    }
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper, queryClient };
+};
+
+const mockTasks = [
+  {
+    id: 'task-1',
+    name: 'Test Task 1',
+    description: 'Description 1',
+    incidentId: 'incident-1',
+    author: { username: 'john.doe', displayName: 'John Doe' },
+    assignee: { username: 'jane.smith', displayName: 'Jane Smith' },
+    status: 'ToDo',
+    sequence: '1',
+    createdAt: '2025-01-01T10:00:00Z'
+  },
+  {
+    id: 'task-2',
+    name: 'Test Task 2',
+    description: 'Description 2',
+    incidentId: 'incident-1',
+    author: { username: 'jane.smith', displayName: 'Jane Smith' },
+    assignee: { username: 'john.doe', displayName: 'John Doe' },
+    status: 'InProgress',
+    sequence: '2',
+    createdAt: '2025-01-01T11:00:00Z'
+  }
+];
+
+describe('useTasks', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('fetches tasks for a specific incident', async () => {
+    (get as jest.Mock).mockResolvedValueOnce(mockTasks);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useTasks('incident-1'), {
+      wrapper
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(get).toHaveBeenCalledWith('/incident/incident-1/tasks');
+    expect(result.current.data).toEqual(mockTasks);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('does not fetch when no incident ID is provided', () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useTasks(undefined), {
+      wrapper
+    });
+
+    expect(get).not.toHaveBeenCalled();
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('handles errors when fetching tasks', async () => {
+    const errorMessage = 'Failed to fetch tasks';
+    (get as jest.Mock).mockRejectedValueOnce(new Error(errorMessage));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useTasks('incident-1'), {
+      wrapper
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.isError).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+});
+
+describe('useAllTasks', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('fetches all tasks', async () => {
+    const allTasks = [
+      ...mockTasks,
+      {
+        id: 'task-3',
+        name: 'Test Task 3',
+        description: 'Description 3',
+        incidentId: 'incident-2',
+        author: { username: 'admin.user', displayName: 'Admin User' },
+        assignee: { username: 'john.doe', displayName: 'John Doe' },
+        status: 'Done',
+        sequence: '1',
+        createdAt: '2025-01-01T12:00:00Z'
+      }
+    ];
+
+    (get as jest.Mock).mockResolvedValueOnce(allTasks);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAllTasks(), {
+      wrapper
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(get).toHaveBeenCalledWith('/tasks');
+    expect(result.current.data).toEqual(allTasks);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('handles errors when fetching all tasks', async () => {
+    const errorMessage = 'Failed to fetch all tasks';
+    (get as jest.Mock).mockRejectedValueOnce(new Error(errorMessage));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAllTasks(), {
+      wrapper
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.isError).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+});

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -8,7 +8,7 @@ import { useCreateLogEntry, useLogEntries } from './useLogEntries';
 import { useLogEntriesUpdates } from './useLogEntriesUpdates';
 import { useNotifications, useReadNotification } from './useNotifications';
 import { useOutsideClick } from './useOutsideClick';
-import { useTasks, useUpdateTaskAssignee, useUpdateTaskStatus } from './useTasks';
+import { useTasks, useUpdateTaskAssignee, useUpdateTaskStatus, useAllTasks } from './useTasks';
 import { useToast, useToastEntries } from './useToasts';
 
 export {
@@ -21,6 +21,7 @@ export {
   useNotifications,
   useReadNotification,
   useTasks,
+  useAllTasks,
   useUpdateTaskAssignee,
   useUpdateTaskStatus,
   useUsers,

--- a/frontend/src/hooks/useTasks.ts
+++ b/frontend/src/hooks/useTasks.ts
@@ -21,6 +21,13 @@ export const useTasks = (incidentId?: string) =>
     staleTime: 5 * 60 * 1000 // 5 minutes
   });
 
+export const useAllTasks = () =>
+  useQuery<Task[]>({
+    queryKey: ['tasks'],
+    queryFn: () => get('/tasks'),
+    staleTime: 5 * 60 * 1000 // 5 minutes
+  });
+
 export const useUpdateTaskStatus = (incidentId?: string) => {
   const queryClient = useQueryClient();
   const { createLogEntry } = useCreateLogEntry(incidentId);

--- a/frontend/src/pages/IncidentTasks.tsx
+++ b/frontend/src/pages/IncidentTasks.tsx
@@ -1,0 +1,381 @@
+// SPDX-License-Identifier: Apache-2.0
+// © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+// and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
+
+import { Box, Button, Typography } from '@mui/material';
+import { type Task, type TaskStatus } from 'common/Task';
+import { type User } from 'common/User';
+import { useEffect, useState } from 'react';
+import { useLocation, useParams } from 'react-router-dom';
+import { FormField, PageTitle } from '../components';
+import { FormFooter } from '../components/Form';
+import PageWrapper from '../components/PageWrapper';
+import Status from '../components/Status';
+import { useAuth, useIncidents, useUsers } from '../hooks';
+import { useResponsive } from '../hooks/useResponsiveHook';
+import { useTasks, useUpdateTaskAssignee, useUpdateTaskStatus } from '../hooks/useTasks';
+import { Format } from '../utils';
+import { FieldValueType, ValidationError } from '../utils/types';
+
+const IncidentTasks = () => {
+  const { incidentId } = useParams();
+  const query = useIncidents();
+  const { users } = useUsers();
+  const { data: tasks, isLoading: tasksLoading } = useTasks(incidentId);
+  const { user } = useAuth();
+  const { isBelowMd } = useResponsive();
+  const updateTaskStatus = useUpdateTaskStatus(incidentId);
+  const updateTaskAssignee = useUpdateTaskAssignee(incidentId);
+  const location = useLocation();
+
+  const defaultUpdateTask = {
+    id: undefined,
+    loading: false,
+    status: { edit: false, value: undefined, error: undefined },
+    assignee: { edit: false, value: undefined, error: undefined }
+  };
+
+  const [updateTask, setUpdateTask] = useState<{
+    id: string | undefined;
+    loading: boolean;
+    status: { edit: boolean; value: TaskStatus | undefined; error: ValidationError | undefined };
+    assignee: { edit: boolean; value: User | undefined; error: ValidationError | undefined };
+  }>(defaultUpdateTask);
+  const [displayErrors, setDisplayErrors] = useState(false);
+  const [highlightedTaskId, setHighlightedTaskId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (location.hash) {
+      const elementId = location.hash.replace('#', '');
+      const element = document.getElementById(elementId);
+      if (element) {
+        element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        setHighlightedTaskId(elementId);
+
+        setTimeout(() => {
+          setHighlightedTaskId(null);
+        }, 2000);
+      }
+    }
+  }, [location]);
+
+  const hasTasks = Array.isArray(tasks) && tasks.length > 0;
+  const incident = query?.data?.find((inc) => inc.id === incidentId);
+  const resetUpdateTask = () => setUpdateTask(defaultUpdateTask);
+  const assignees = users?.map(Format.mentionable.user).map(({ id, label }) => ({
+    value: id,
+    label
+  }));
+
+  if (!incident) return null;
+
+  if (tasksLoading) {
+    return (
+      <PageWrapper>
+        <PageTitle
+          title={Format.incident.type(incident.type)}
+          subtitle={incident.name}
+          stage={incident.stage}
+        />
+        <Typography>Loading tasks...</Typography>
+      </PageWrapper>
+    );
+  }
+
+  const canUpdateTask = (task: Task) => {
+    const currentUsername = user.current?.username;
+    const taskAssigneeUsername = task.assignee?.username;
+    return currentUsername === taskAssigneeUsername;
+  };
+
+  const handleOnClickStatus = (task: Task) => {
+    if (task.id === updateTask.id) return setUpdateTask(defaultUpdateTask);
+    return setUpdateTask({
+      ...updateTask,
+      id: task.id,
+      status: {
+        ...updateTask.status,
+        edit: true,
+        value: task.status,
+        error: { fieldId: 'name', error: 'Please select a new status.' }
+      }
+    });
+  };
+
+  const handleOnClickAssignee = (task: Task) => {
+    if (task.id === updateTask.id) return setUpdateTask(defaultUpdateTask);
+    return setUpdateTask({
+      ...updateTask,
+      id: task.id,
+      assignee: {
+        ...updateTask.assignee,
+        edit: true,
+        error: { fieldId: 'assignee', error: 'Please select a new user.' }
+      }
+    });
+  };
+
+  const handleUpdateStatus = (task: Task, value: FieldValueType) => {
+    if (value) {
+      let isValidNextStep = false;
+      if (task.status === 'ToDo') {
+        isValidNextStep = value === 'InProgress' || value === 'Done';
+      } else if (task.status === 'InProgress') {
+        isValidNextStep = value === 'Done';
+      }
+
+      let error: ValidationError | undefined;
+      if (task.status === value) {
+        error = { fieldId: 'name', error: 'Please select a new status' };
+      } else if (!isValidNextStep) {
+        error = { fieldId: 'name', error: 'Cannot move backwards in status progression' };
+      }
+
+      setUpdateTask({
+        ...updateTask,
+        status: { ...updateTask.status, value: value as TaskStatus, error }
+      });
+    }
+  };
+
+  const handleUpdateAssignee = (task: Task, value: FieldValueType) => {
+    const findAssignee = assignees?.find((user) => user.value === value);
+    if (findAssignee) {
+      const error =
+        findAssignee.value === task.assignee?.username.replace(/\s+/g, '.').toLowerCase()
+          ? { fieldId: 'assignee', error: 'Please select a new user' }
+          : undefined;
+      setUpdateTask({
+        ...updateTask,
+        assignee: {
+          ...updateTask.assignee,
+          value: { username: findAssignee.value, displayName: findAssignee.label },
+          error
+        }
+      });
+    }
+  };
+
+  const handleOnCancel = () => {
+    setUpdateTask(defaultUpdateTask);
+  };
+
+  const handleOnSubmit = (task: Task) => {
+    if (updateTask.status.edit && updateTask.status.value) {
+      updateTaskStatus.mutate(
+        { task: { ...task, status: updateTask.status.value } },
+        { onSettled: resetUpdateTask }
+      );
+    }
+    if (updateTask.assignee.edit && updateTask.assignee.value) {
+      updateTaskAssignee.mutate(
+        { task: { ...task, assignee: updateTask.assignee.value } },
+        { onSettled: resetUpdateTask }
+      );
+    }
+  };
+
+  return (
+    <PageWrapper>
+      <PageTitle
+        title={Format.incident.type(incident.type)}
+        subtitle={incident.name}
+        stage={incident.stage}
+      />
+      <Box display="flex" flexDirection="column" gap={2}>
+        {hasTasks ? (
+          tasks.map((task) => {
+            const formatDefaultAssignee =
+              task.assignee?.username.replace(/\s+/g, '.').toLowerCase() ?? '';
+            const isTaskUpdating = updateTask.id === task.id;
+            const isStatusUpdating = isTaskUpdating && updateTask.status.edit;
+            const isAssigneeUpdating = isTaskUpdating && updateTask.assignee.edit;
+            const canUpdate = canUpdateTask(task);
+
+            const validationErrors = () => {
+              if (isStatusUpdating) {
+                return updateTask.status.error ? [updateTask.status.error] : [];
+              }
+              if (isAssigneeUpdating) {
+                return updateTask.assignee.error ? [updateTask.assignee.error] : [];
+              }
+              return [];
+            };
+
+            const statusValue = () => task.status ?? 'ToDo';
+
+            return (
+              <Box
+                key={task.id}
+                id={task.id}
+                display="flex"
+                flexDirection="column"
+                bgcolor="background.default"
+                padding={2}
+                gap={2}
+                sx={{
+                  border: highlightedTaskId === task.id ? '2px solid' : '1px solid',
+                  borderColor: highlightedTaskId === task.id ? 'accent.main' : 'border.main',
+                  borderRadius: 1
+                }}
+              >
+                <Box
+                  display="flex"
+                  flexDirection="column"
+                  bgcolor="background.default"
+                  padding={2}
+                  gap={2}
+                >
+                  <Box display="flex" flexDirection={isBelowMd ? 'column' : 'row-reverse'} gap={2}>
+                    <Box
+                      display="flex"
+                      flexDirection="row"
+                      justifyContent={isBelowMd ? 'flex-start' : 'flex-end'}
+                      gap={2}
+                      flexGrow={0.5}
+                    >
+                      <Button
+                        type="button"
+                        size="small"
+                        variant="contained"
+                        onClick={() => handleOnClickStatus(task)}
+                        disabled={isAssigneeUpdating || !canUpdate || task.status === 'Done'}
+                        fullWidth={isBelowMd}
+                        sx={{ maxHeight: 40 }}
+                      >
+                        Change Status
+                      </Button>
+                      <Button
+                        type="button"
+                        size="small"
+                        variant="contained"
+                        onClick={() => handleOnClickAssignee(task)}
+                        fullWidth={isBelowMd}
+                        disabled={isStatusUpdating || !canUpdate || task.status === 'Done'}
+                        sx={{ maxHeight: 40 }}
+                      >
+                        Change Assignee
+                      </Button>
+                    </Box>
+
+                    <Box
+                      display="flex"
+                      flexDirection={isBelowMd ? 'column' : 'row'}
+                      justifyContent="space-between"
+                      gap={2}
+                      flexGrow={1}
+                      alignItems="flex-start"
+                    >
+                      <Box display="flex" flexDirection="column" gap={2} flex={1}>
+                        <Box display="flex" flexDirection="column" gap={1}>
+                          <Typography variant="body1" fontWeight="bold">
+                            Current Status
+                          </Typography>
+                          <Status width="fit-content" status={statusValue()} />
+                        </Box>
+                        {isStatusUpdating && (
+                          <Box component="ul" width="100%">
+                            <FormField
+                              component="li"
+                              field={{
+                                id: 'name',
+                                type: 'Select',
+                                label: 'New Status',
+                                value: updateTask.status.value ?? task.status,
+                                options: [
+                                  { value: 'ToDo', label: 'To Do' },
+                                  { value: 'InProgress', label: 'In Progress' },
+                                  { value: 'Done', label: 'Done' }
+                                ]
+                              }}
+                              error={
+                                displayErrors
+                                  ? (updateTask.status.error as ValidationError)
+                                  : undefined
+                              }
+                              onChange={(_, value) => handleUpdateStatus(task, value)}
+                            />
+                          </Box>
+                        )}
+
+                        <Box display="flex" flexDirection="column" gap={1}>
+                          <Typography variant="body1" fontWeight="bold">
+                            Task description
+                          </Typography>
+                          <Typography variant="body1">{task.description}</Typography>
+                        </Box>
+
+                        <Box display="flex" flexDirection="column" gap={1}>
+                          <Typography variant="body1" fontWeight="bold">
+                            Assigned by
+                          </Typography>
+                          <Typography variant="body1">{Format.user(task.author)}</Typography>
+                        </Box>
+                      </Box>
+
+                      <Box display="flex" flexDirection="column" gap={2} flex={1}>
+                        <Box display="flex" flexDirection="column" gap={1}>
+                          <Typography variant="body1" fontWeight="bold">
+                            Assigned to
+                          </Typography>
+                          <Typography>{Format.user(task.assignee)}</Typography>
+                          {isAssigneeUpdating && (
+                            <Box component="ul" width="100%">
+                              <FormField
+                                component="li"
+                                field={{
+                                  id: 'assignee',
+                                  type: 'Select',
+                                  label: 'Assign to',
+                                  value: formatDefaultAssignee,
+                                  options: assignees ?? []
+                                }}
+                                error={
+                                  displayErrors
+                                    ? (updateTask.assignee.error as ValidationError)
+                                    : undefined
+                                }
+                                onChange={(_, value) => handleUpdateAssignee(task, value)}
+                              />
+                            </Box>
+                          )}
+                        </Box>
+
+                        <Box display="flex" flexDirection="column" gap={1}>
+                          <Typography variant="body1" fontWeight="bold">
+                            Date and time recorded
+                          </Typography>
+                          <Typography variant="body1">
+                            {Format.dateAndTimeMobile(task.createdAt)}
+                          </Typography>
+                        </Box>
+                      </Box>
+                    </Box>
+                  </Box>
+
+                  <Box />
+                  {(isStatusUpdating || isAssigneeUpdating) && (
+                    <FormFooter
+                      validationErrors={validationErrors()}
+                      onShowValidationErrors={() => setDisplayErrors(!displayErrors)}
+                      onCancel={handleOnCancel}
+                      onSubmit={() => handleOnSubmit(task)}
+                      loading={updateTask.loading}
+                    />
+                  )}
+                </Box>
+              </Box>
+            );
+          })
+        ) : (
+          <>
+            <h3>There are currently no tasks.</h3>
+            <hr />
+          </>
+        )}
+      </Box>
+    </PageWrapper>
+  );
+};
+
+export default IncidentTasks;

--- a/frontend/src/pages/Notifications.tsx
+++ b/frontend/src/pages/Notifications.tsx
@@ -4,13 +4,14 @@
 
 import NotificationsIcon from '@mui/icons-material/Notifications';
 import NotificationsNoneOutlinedIcon from '@mui/icons-material/NotificationsNoneOutlined';
-import { Box, List, ListItem, Tab, Tabs, Typography } from '@mui/material';
+import { Box, Tab, Tabs, Typography } from '@mui/material';
 import { type Notification } from 'common/Notification';
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import getHandler from '../components/Notifications/handlers';
 import { useNotifications, useReadNotification } from '../hooks';
 import { Format } from '../utils';
+import DataList, { ListRow } from '../components/DataList';
 
 interface TabPanelProps {
   readonly children?: React.ReactNode;
@@ -57,18 +58,13 @@ function NotificationDot() {
   return (
     <Box
       sx={{
-        marginTop: 1,
-        width: 10,
-        height: 10,
-        borderRadius: '9999px',
-        backgroundColor: 'primary.main'
+        width: 12,
+        height: 12,
+        borderRadius: '50%', 
+        backgroundColor: 'primary.main',
       }}
     />
   );
-}
-
-function NotificationSpacer() {
-  return <Box sx={{ width: 12, flexShrink: 0 }} />;
 }
 
 export default function Notifications() {
@@ -107,55 +103,18 @@ export default function Notifications() {
     }
   }, [navigate, readNotification]);
 
-  const renderNotificationItem = useCallback((notification: Notification) => {
-    try {
-      const handler = getHandler(notification, navigate);
-      return (
-        <ListItem
-          key={notification.id}
-          sx={{
-            padding: 2,
-            cursor: 'pointer',
-            backgroundColor: 'background.paper',
-            '&:hover': { backgroundColor: 'action.hover' }
-          }}
-          onClick={() => handleNotificationClick(notification)}
-        >
-          <Box sx={{ width: '100%', display: 'flex', gap: 2 }}>
-            {!notification.read ? <NotificationDot /> : <NotificationSpacer />}
-
-            <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 1 }}>
-              <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                <Typography
-                  variant="body1"
-                  color="primary"
-                  sx={{ fontWeight: notification.read ? 'normal' : 'bold' }}
-                >
-                  {handler.title}
-                </Typography>
-                <Typography color="text.secondary">
-                  {Format.relativeTime(notification.dateTime)}
-                </Typography>
-              </Box>
-
-              <Box>{handler.Content}</Box>
-
-              {notification.incidentTitle && (
-                <Typography
-                  variant="caption"
-                  color="text.secondary"
-                  sx={{ fontSize: '0.75rem', fontWeight: 500 }}
-                >
-                  {handler.footer}
-                </Typography>
-              )}
-            </Box>
-          </Box>
-        </ListItem>
-      );
-    } catch {
-      return null;
-    }
+  const toRow = useCallback((n: Notification): ListRow => {
+    const handler = getHandler(n, navigate);
+    return {
+      key: n.id,
+      title: handler.title,
+      content: handler.Content,
+      footer: handler.footer,
+      metaRight: Format.relativeTime(n.dateTime),
+      titleDot: !n.read ? <NotificationDot /> : undefined,
+      emphasizeTitle: !n.read,
+      onClick: () => handleNotificationClick(n)
+    };
   }, [navigate, handleNotificationClick]);
 
   return (
@@ -194,11 +153,7 @@ export default function Notifications() {
           {notificationsArray.length === 0 ? (
             <EmptyState icon={NotificationsNoneOutlinedIcon} title="There are no notifications" />
           ) : (
-            <List sx={{ display: 'flex', flexDirection: 'column', padding: 0, gap: '1px' }}>
-              {notificationsArray.map((notification) => (
-                <Box key={notification.id}>{renderNotificationItem(notification)}</Box>
-              ))}
-            </List>
+            <DataList items={notificationsArray.map(toRow)} />
           )}
         </TabPanel>
 
@@ -206,11 +161,7 @@ export default function Notifications() {
           {unreadNotifications.length === 0 ? (
             <EmptyState icon={NotificationsIcon} title="You have no unread notifications" />
           ) : (
-            <List sx={{ display: 'flex', flexDirection: 'column', padding: 0, gap: '1px' }}>
-              {unreadNotifications.map((notification) => (
-                <Box key={notification.id}>{renderNotificationItem(notification)}</Box>
-              ))}
-            </List>
+            <DataList items={unreadNotifications.map(toRow)} />
           )}
         </TabPanel>
       </Box>

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -2,380 +2,253 @@
 // © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
 // and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
+import AddCircleIcon from '@mui/icons-material/AddCircle';
 import { Box, Button, Typography } from '@mui/material';
-import { type Task, type TaskStatus } from 'common/Task';
-import { type User } from 'common/User';
-import { useEffect, useState } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
-import { FormField, PageTitle } from '../components';
-import { FormFooter } from '../components/Form';
-import PageWrapper from '../components/PageWrapper';
-import Status from '../components/Status';
-import { useAuth, useIncidents, useUsers } from '../hooks';
-import { useResponsive } from '../hooks/useResponsiveHook';
-import { useTasks, useUpdateTaskAssignee, useUpdateTaskStatus } from '../hooks/useTasks';
+import { useNavigate } from 'react-router-dom';
+import { useState, useMemo } from 'react';
+import { Task, TaskStatus } from 'common/Task';
+import DataList, { ListRow } from '../components/DataList';
+import { useIncidents, useAllTasks } from '../hooks';
 import { Format } from '../utils';
-import { FieldValueType, ValidationError } from '../utils/types';
 
-const Tasks = () => {
-  const { incidentId } = useParams();
-  const query = useIncidents();
-  const { users } = useUsers();
-  const { data: tasks, isLoading: tasksLoading } = useTasks(incidentId);
-  const { user } = useAuth();
-  const { isBelowMd } = useResponsive();
-  const updateTaskStatus = useUpdateTaskStatus(incidentId);
-  const updateTaskAssignee = useUpdateTaskAssignee(incidentId);
-  const location = useLocation();
+import { SortAndFilter } from '../components/SortFilter/SortAndFilter';
+import { buildTaskFilters, taskSort } from '../components/SortFilter/schemas/task-schema';
+import { type QueryState } from '../components/SortFilter/filter-types';
+import { countActive } from '../components/SortFilter/filter-utils';
 
-  const defaultUpdateTask = {
-    id: undefined,
-    loading: false,
-    status: { edit: false, value: undefined, error: undefined },
-    assignee: { edit: false, value: undefined, error: undefined }
-  };
+function StatusDot({ status }: { status: TaskStatus }) {
+  let color: string;
+  let borderColor: string;
 
-  const [updateTask, setUpdateTask] = useState<{
-    id: string | undefined;
-    loading: boolean;
-    status: { edit: boolean; value: TaskStatus | undefined; error: ValidationError | undefined };
-    assignee: { edit: boolean; value: User | undefined; error: ValidationError | undefined };
-  }>(defaultUpdateTask);
-  const [displayErrors, setDisplayErrors] = useState(false);
-  const [highlightedTaskId, setHighlightedTaskId] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (location.hash) {
-      const elementId = location.hash.replace('#', '');
-      const element = document.getElementById(elementId);
-      if (element) {
-        element.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        setHighlightedTaskId(elementId);
-
-        setTimeout(() => {
-          setHighlightedTaskId(null);
-        }, 2000);
-      }
-    }
-  }, [location]);
-
-  const hasTasks = Array.isArray(tasks) && tasks.length > 0;
-  const incident = query?.data?.find((inc) => inc.id === incidentId);
-  const resetUpdateTask = () => setUpdateTask(defaultUpdateTask);
-  const assignees = users?.map(Format.mentionable.user).map(({ id, label }) => ({
-    value: id,
-    label
-  }));
-
-  if (!incident) return null;
-
-  if (tasksLoading) {
-    return (
-      <PageWrapper>
-        <PageTitle
-          title={Format.incident.type(incident.type)}
-          subtitle={incident.name}
-          stage={incident.stage}
-        />
-        <Typography>Loading tasks...</Typography>
-      </PageWrapper>
-    );
+  if (status === 'Done') {
+    color = '#9DF5A8';
+    borderColor = '#239932';
+  } else if (status === 'InProgress') {
+    color = '#F5CF9D';
+    borderColor = '#FF6D24';
+  } else {
+    color = '#A5D3F5';
+    borderColor = '#3C3DE9';
   }
 
-  const canUpdateTask = (task: Task) => {
-    const currentUsername = user.current?.username;
-    const taskAssigneeUsername = task.assignee?.username;
-    return currentUsername === taskAssigneeUsername;
-  };
-
-  const handleOnClickStatus = (task: Task) => {
-    if (task.id === updateTask.id) return setUpdateTask(defaultUpdateTask);
-    return setUpdateTask({
-      ...updateTask,
-      id: task.id,
-      status: {
-        ...updateTask.status,
-        edit: true,
-        value: task.status,
-        error: { fieldId: 'name', error: 'Please select a new status.' }
-      }
-    });
-  };
-
-  const handleOnClickAssignee = (task: Task) => {
-    if (task.id === updateTask.id) return setUpdateTask(defaultUpdateTask);
-    return setUpdateTask({
-      ...updateTask,
-      id: task.id,
-      assignee: {
-        ...updateTask.assignee,
-        edit: true,
-        error: { fieldId: 'assignee', error: 'Please select a new user.' }
-      }
-    });
-  };
-
-  const handleUpdateStatus = (task: Task, value: FieldValueType) => {
-    if (value) {
-      let isValidNextStep = false;
-      if (task.status === 'ToDo') {
-        isValidNextStep = value === 'InProgress' || value === 'Done';
-      } else if (task.status === 'InProgress') {
-        isValidNextStep = value === 'Done';
-      }
-
-      let error: ValidationError | undefined;
-      if (task.status === value) {
-        error = { fieldId: 'name', error: 'Please select a new status' };
-      } else if (!isValidNextStep) {
-        error = { fieldId: 'name', error: 'Cannot move backwards in status progression' };
-      }
-
-      setUpdateTask({
-        ...updateTask,
-        status: { ...updateTask.status, value: value as TaskStatus, error }
-      });
-    }
-  };
-
-  const handleUpdateAssignee = (task: Task, value: FieldValueType) => {
-    const findAssignee = assignees?.find((user) => user.value === value);
-    if (findAssignee) {
-      const error =
-        findAssignee.value === task.assignee?.username.replace(/\s+/g, '.').toLowerCase()
-          ? { fieldId: 'assignee', error: 'Please select a new user' }
-          : undefined;
-      setUpdateTask({
-        ...updateTask,
-        assignee: {
-          ...updateTask.assignee,
-          value: { username: findAssignee.value, displayName: findAssignee.label },
-          error
-        }
-      });
-    }
-  };
-
-  const handleOnCancel = () => {
-    setUpdateTask(defaultUpdateTask);
-  };
-
-  const handleOnSubmit = (task: Task) => {
-    if (updateTask.status.edit && updateTask.status.value) {
-      updateTaskStatus.mutate(
-        { task: { ...task, status: updateTask.status.value } },
-        { onSettled: resetUpdateTask }
-      );
-    }
-    if (updateTask.assignee.edit && updateTask.assignee.value) {
-      updateTaskAssignee.mutate(
-        { task: { ...task, assignee: updateTask.assignee.value } },
-        { onSettled: resetUpdateTask }
-      );
-    }
-  };
-
   return (
-    <PageWrapper>
-      <PageTitle
-        title={Format.incident.type(incident.type)}
-        subtitle={incident.name}
-        stage={incident.stage}
-      />
-      <Box display="flex" flexDirection="column" gap={2}>
-        {hasTasks ? (
-          tasks.map((task) => {
-            const formatDefaultAssignee =
-              task.assignee?.username.replace(/\s+/g, '.').toLowerCase() ?? '';
-            const isTaskUpdating = updateTask.id === task.id;
-            const isStatusUpdating = isTaskUpdating && updateTask.status.edit;
-            const isAssigneeUpdating = isTaskUpdating && updateTask.assignee.edit;
-            const canUpdate = canUpdateTask(task);
-
-            const validationErrors = () => {
-              if (isStatusUpdating) {
-                return updateTask.status.error ? [updateTask.status.error] : [];
-              }
-              if (isAssigneeUpdating) {
-                return updateTask.assignee.error ? [updateTask.assignee.error] : [];
-              }
-              return [];
-            };
-
-            const statusValue = () => task.status ?? 'ToDo';
-
-            return (
-              <Box
-                key={task.id}
-                id={task.id}
-                display="flex"
-                flexDirection="column"
-                bgcolor="background.default"
-                padding={2}
-                gap={2}
-                sx={{
-                  border: highlightedTaskId === task.id ? '2px solid' : '1px solid',
-                  borderColor: highlightedTaskId === task.id ? 'accent.main' : 'border.main',
-                  borderRadius: 1
-                }}
-              >
-                <Box
-                  display="flex"
-                  flexDirection="column"
-                  bgcolor="background.default"
-                  padding={2}
-                  gap={2}
-                >
-                  <Box display="flex" flexDirection={isBelowMd ? 'column' : 'row-reverse'} gap={2}>
-                    <Box
-                      display="flex"
-                      flexDirection="row"
-                      justifyContent={isBelowMd ? 'flex-start' : 'flex-end'}
-                      gap={2}
-                      flexGrow={0.5}
-                    >
-                      <Button
-                        type="button"
-                        size="small"
-                        variant="contained"
-                        onClick={() => handleOnClickStatus(task)}
-                        disabled={isAssigneeUpdating || !canUpdate || task.status === 'Done'}
-                        fullWidth={isBelowMd}
-                        sx={{ maxHeight: 40 }}
-                      >
-                        Change Status
-                      </Button>
-                      <Button
-                        type="button"
-                        size="small"
-                        variant="contained"
-                        onClick={() => handleOnClickAssignee(task)}
-                        fullWidth={isBelowMd}
-                        disabled={isStatusUpdating || !canUpdate || task.status === 'Done'}
-                        sx={{ maxHeight: 40 }}
-                      >
-                        Change Assignee
-                      </Button>
-                    </Box>
-
-                    <Box
-                      display="flex"
-                      flexDirection={isBelowMd ? 'column' : 'row'}
-                      justifyContent="space-between"
-                      gap={2}
-                      flexGrow={1}
-                      alignItems="flex-start"
-                    >
-                      <Box display="flex" flexDirection="column" gap={2} flex={1}>
-                        <Box display="flex" flexDirection="column" gap={1}>
-                          <Typography variant="body1" fontWeight="bold">
-                            Current Status
-                          </Typography>
-                          <Status width="fit-content" status={statusValue()} />
-                        </Box>
-                        {isStatusUpdating && (
-                          <Box component="ul" width="100%">
-                            <FormField
-                              component="li"
-                              field={{
-                                id: 'name',
-                                type: 'Select',
-                                label: 'New Status',
-                                value: updateTask.status.value ?? task.status,
-                                options: [
-                                  { value: 'ToDo', label: 'To Do' },
-                                  { value: 'InProgress', label: 'In Progress' },
-                                  { value: 'Done', label: 'Done' }
-                                ]
-                              }}
-                              error={
-                                displayErrors
-                                  ? (updateTask.status.error as ValidationError)
-                                  : undefined
-                              }
-                              onChange={(_, value) => handleUpdateStatus(task, value)}
-                            />
-                          </Box>
-                        )}
-
-                        <Box display="flex" flexDirection="column" gap={1}>
-                          <Typography variant="body1" fontWeight="bold">
-                            Task description
-                          </Typography>
-                          <Typography variant="body1">{task.description}</Typography>
-                        </Box>
-
-                        <Box display="flex" flexDirection="column" gap={1}>
-                          <Typography variant="body1" fontWeight="bold">
-                            Assigned by
-                          </Typography>
-                          <Typography variant="body1">{Format.user(task.author)}</Typography>
-                        </Box>
-                      </Box>
-
-                      <Box display="flex" flexDirection="column" gap={2} flex={1}>
-                        <Box display="flex" flexDirection="column" gap={1}>
-                          <Typography variant="body1" fontWeight="bold">
-                            Assigned to
-                          </Typography>
-                          <Typography>{Format.user(task.assignee)}</Typography>
-                          {isAssigneeUpdating && (
-                            <Box component="ul" width="100%">
-                              <FormField
-                                component="li"
-                                field={{
-                                  id: 'assignee',
-                                  type: 'Select',
-                                  label: 'Assign to',
-                                  value: formatDefaultAssignee,
-                                  options: assignees ?? []
-                                }}
-                                error={
-                                  displayErrors
-                                    ? (updateTask.assignee.error as ValidationError)
-                                    : undefined
-                                }
-                                onChange={(_, value) => handleUpdateAssignee(task, value)}
-                              />
-                            </Box>
-                          )}
-                        </Box>
-
-                        <Box display="flex" flexDirection="column" gap={1}>
-                          <Typography variant="body1" fontWeight="bold">
-                            Date and time recorded
-                          </Typography>
-                          <Typography variant="body1">
-                            {Format.dateAndTimeMobile(task.createdAt)}
-                          </Typography>
-                        </Box>
-                      </Box>
-                    </Box>
-                  </Box>
-
-                  <Box />
-                  {(isStatusUpdating || isAssigneeUpdating) && (
-                    <FormFooter
-                      validationErrors={validationErrors()}
-                      onShowValidationErrors={() => setDisplayErrors(!displayErrors)}
-                      onCancel={handleOnCancel}
-                      onSubmit={() => handleOnSubmit(task)}
-                      loading={updateTask.loading}
-                    />
-                  )}
-                </Box>
-              </Box>
-            );
-          })
-        ) : (
-          <>
-            <h3>There are currently no tasks.</h3>
-            <hr />
-          </>
-        )}
-      </Box>
-    </PageWrapper>
+    <Box
+      sx={{
+        width: 12,
+        height: 12,
+        borderRadius: '50%',
+        backgroundColor: color,
+        border: '1px solid',
+        borderColor,
+        flexShrink: 0
+      }}
+    />
   );
+}
+
+const DEFAULT_QUERY_STATE: QueryState = {
+  values: {
+    status: ['ToDo', 'InProgress'] // Default to show only active tasks
+  },
+  sort: { by: 'date_desc', direction: 'desc' }
 };
 
-export default Tasks;
+export default function Tasks() {
+  const navigate = useNavigate();
+  const { data: incidents } = useIncidents();
+  const { data: tasksData } = useAllTasks();
+
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const [queryState, setQueryState] = useState<QueryState>(DEFAULT_QUERY_STATE);
+
+  const allTasks: Task[] = useMemo(() => tasksData ?? [], [tasksData]);
+  const incidentNameById = new Map((incidents ?? []).map((i) => [i.id, i.name] as const));
+
+  const allAuthors = useMemo(() => {
+    const seen = new Set<string>();
+    return allTasks
+      .map((t) => t.author)
+      .filter((user) => {
+        if (!user || seen.has(user.username)) return false;
+        seen.add(user.username);
+        return true;
+      })
+      .sort((a, b) => a.displayName.localeCompare(b.displayName));
+  }, [allTasks]);
+
+  const allAssignees = useMemo(() => {
+    const seen = new Set<string>();
+    return allTasks
+      .map((t) => t.assignee)
+      .filter((user) => {
+        if (!user || seen.has(user.username)) return false;
+        seen.add(user.username);
+        return true;
+      })
+      .sort((a, b) => a.displayName.localeCompare(b.displayName));
+  }, [allTasks]);
+
+  const taskFilters = useMemo(() => {
+    const incidentList = (incidents ?? []).map((i) => ({ id: i.id, name: i.name }));
+    return buildTaskFilters(allAuthors, allAssignees, incidentList);
+  }, [allAuthors, allAssignees, incidents]);
+
+  const visibleTasks = useMemo(() => {
+    const items = allTasks.slice();
+    const v = queryState.values;
+
+    const selectedAuthors = new Set<string>((v.author as string[]) ?? []);
+    const selectedAssignees = new Set<string>((v.assignee as string[]) ?? []);
+    const selectedIncidents = new Set<string>((v.incident as string[]) ?? []);
+    const selectedStatuses = new Set<string>((v.status as string[]) ?? []);
+
+    const filtered = items.filter((task) => {
+      if (selectedAuthors.size > 0) {
+        if (!selectedAuthors.has(task.author.username)) return false;
+      }
+
+      if (selectedAssignees.size > 0) {
+        if (!selectedAssignees.has(task.assignee.username)) return false;
+      }
+
+      if (selectedIncidents.size > 0) {
+        if (!selectedIncidents.has(task.incidentId)) return false;
+      }
+
+      if (selectedStatuses.size > 0) {
+        if (!selectedStatuses.has(task.status)) return false;
+      }
+
+      return true;
+    });
+
+    const sortBy = queryState.sort?.by || 'date_desc';
+    filtered.sort((a, b) => {
+      switch (sortBy) {
+        case 'name_asc':
+          return a.name.localeCompare(b.name);
+        case 'name_desc':
+          return b.name.localeCompare(a.name);
+        case 'author_asc':
+          return a.author.displayName.localeCompare(b.author.displayName);
+        case 'author_desc':
+          return b.author.displayName.localeCompare(a.author.displayName);
+        case 'date_asc':
+          return a.createdAt.localeCompare(b.createdAt);
+        case 'date_desc':
+        default:
+          return b.createdAt.localeCompare(a.createdAt);
+      }
+    });
+
+    return filtered;
+  }, [allTasks, queryState]);
+
+  const activeFilterCount = useMemo(() => countActive(queryState.values), [queryState.values]);
+
+  const onAddTask = () => {
+    // eslint-disable-next-line no-alert
+    alert('Not implemented');
+  };
+
+  const handleOpenFilters = () => setFiltersOpen(true);
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <Box sx={{ padding: { xs: 2, md: 3 } }}>
+        <Typography variant="h4" sx={{ fontSize: { xs: '1.5rem', md: '2rem' } }}>
+          Tasks
+        </Typography>
+      </Box>
+
+      <Box
+        sx={{
+          paddingX: { xs: 2, md: 3 },
+          pb: 2,
+          display: 'flex',
+          gap: 2,
+          flexDirection: 'row'
+        }}
+      >
+        <Button
+          variant="contained"
+          startIcon={<AddCircleIcon />}
+          onClick={onAddTask}
+          color="primary"
+          sx={{
+            flex: { xs: 1, sm: '0 0 auto' },
+            maxWidth: { sm: '200px' }
+          }}
+        >
+          Add Task
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleOpenFilters}
+          color="primary"
+          sx={{
+            flex: { xs: 1, sm: '0 0 auto' },
+            maxWidth: { sm: '200px' }
+          }}
+        >
+          Sort & Filter{activeFilterCount > 0 ? ` (${activeFilterCount})` : ''}
+        </Button>
+      </Box>
+
+      <Box
+        sx={{
+          flex: 1,
+          overflow: 'auto',
+          backgroundColor: 'background.default',
+          p: { xs: 0, md: 0 }
+        }}
+      >
+        {visibleTasks.length === 0 ? (
+          <Box
+            sx={{
+              display: 'flex',
+              padding: 4,
+              flexDirection: 'column',
+              alignItems: 'center',
+              color: 'text.secondary'
+            }}
+          >
+            <Typography variant="h6">
+              {allTasks.length === 0 ? 'No tasks found' : 'No results found'}
+            </Typography>
+            <Typography variant="body2">
+              {allTasks.length === 0
+                ? 'There are currently no tasks.'
+                : 'There are no tasks matching your filters.'}
+            </Typography>
+          </Box>
+        ) : (
+          <DataList
+            items={visibleTasks.map<ListRow>((t) => ({
+              key: t.id,
+              title: t.name,
+              content: (
+                <Typography variant="body2">Assigned to: {Format.user(t.assignee)}</Typography>
+              ),
+              footer: `INCIDENT: ${incidentNameById.get(t.incidentId) ?? t.incidentId}`,
+              titleDot: <StatusDot status={t.status} />,
+              onClick: () => navigate(`/tasks/${t.incidentId}#${t.id}`)
+            }))}
+          />
+        )}
+      </Box>
+
+      <SortAndFilter
+        open={filtersOpen}
+        onClose={() => setFiltersOpen(false)}
+        sort={taskSort}
+        tree={taskFilters}
+        initial={queryState}
+        onApply={(next) => {
+          setQueryState(next);
+          setFiltersOpen(false);
+        }}
+      />
+    </Box>
+  );
+}

--- a/frontend/src/pages/__tests__/Tasks.test.tsx
+++ b/frontend/src/pages/__tests__/Tasks.test.tsx
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: Apache-2.0
+// © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+// and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
+
+import { fireEvent, screen } from '@testing-library/react';
+import { type Task } from 'common/Task';
+import { type Incident } from 'common/Incident';
+import * as hooks from '../../hooks';
+import { providersRender } from '../../test-utils';
+import Tasks from '../Tasks';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate
+}));
+
+const mockIncidents: Incident[] = [
+  {
+    id: 'incident-1',
+    name: 'Test Incident 1',
+    type: 'TerrorismInternational',
+    stage: 'Response',
+    startedAt: '2025-01-01T10:00:00Z',
+    referrer: {
+      email: 'test@example.com',
+      name: 'Test User',
+      organisation: 'Test Org',
+      telephone: '123-456-7890',
+      supportRequested: 'No'
+    }
+  },
+  {
+    id: 'incident-2',
+    name: 'Test Incident 2',
+    type: 'FloodingCoastal',
+    stage: 'Monitoring',
+    startedAt: '2025-01-01T11:00:00Z',
+    referrer: {
+      email: 'test2@example.com',
+      name: 'Test User 2',
+      organisation: 'Test Org 2',
+      telephone: '098-765-4321',
+      supportRequested: 'No'
+    }
+  }
+];
+
+const mockTasks: Task[] = [
+  {
+    id: 'task-1',
+    name: 'High Priority Task',
+    description: 'This is a high priority task',
+    incidentId: 'incident-1',
+    author: { username: 'john.doe', displayName: 'John Doe' },
+    assignee: { username: 'jane.smith', displayName: 'Jane Smith' },
+    status: 'ToDo',
+    sequence: '1',
+    createdAt: '2025-01-01T10:00:00Z'
+  },
+  {
+    id: 'task-2',
+    name: 'In Progress Task',
+    description: 'This task is in progress',
+    incidentId: 'incident-2',
+    author: { username: 'jane.smith', displayName: 'Jane Smith' },
+    assignee: { username: 'bob.wilson', displayName: 'Bob Wilson' },
+    status: 'InProgress',
+    sequence: '2',
+    createdAt: '2025-01-01T11:00:00Z'
+  },
+  {
+    id: 'task-3',
+    name: 'Completed Task',
+    description: 'This task is completed',
+    incidentId: 'incident-1',
+    author: { username: 'alice.jones', displayName: 'Alice Jones' },
+    assignee: { username: 'john.doe', displayName: 'John Doe' },
+    status: 'Done',
+    sequence: '3',
+    createdAt: '2025-01-01T09:00:00Z'
+  }
+];
+
+jest.mock('../../hooks', () => ({
+  useIncidents: jest.fn(() => ({
+    data: mockIncidents
+  })),
+  useAllTasks: jest.fn(() => ({
+    data: mockTasks
+  }))
+}));
+
+describe('Tasks Page', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it('renders the tasks page with title', () => {
+    providersRender(<Tasks />);
+
+    expect(screen.getByText('Tasks')).toBeInTheDocument();
+  });
+
+  it('renders tasks with all required information', () => {
+    providersRender(<Tasks />);
+
+    // Titles (filters out Done status by default)
+    expect(screen.getByText('High Priority Task')).toBeInTheDocument();
+    expect(screen.getByText('In Progress Task')).toBeInTheDocument();
+    expect(screen.queryByText('Completed Task')).not.toBeInTheDocument();
+
+    // Assignee information
+    expect(screen.getByText('Assigned to: Jane Smith')).toBeInTheDocument();
+    expect(screen.getByText('Assigned to: Bob Wilson')).toBeInTheDocument();
+
+    // Incident names in footer
+    expect(screen.getByText('INCIDENT: Test Incident 1')).toBeInTheDocument();
+    expect(screen.getByText('INCIDENT: Test Incident 2')).toBeInTheDocument();
+  });
+
+  it('handles task click navigation', () => {
+    providersRender(<Tasks />);
+
+    const firstTask = screen.getByText('High Priority Task');
+    fireEvent.click(firstTask);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/tasks/incident-1#task-1');
+  });
+
+  it('opens sort and filter dialog when button clicked', () => {
+    providersRender(<Tasks />);
+
+    const filterButton = screen.getByText(/Sort & Filter/);
+    fireEvent.click(filterButton);
+
+    expect(screen.getByText('Sort by')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no tasks exist', () => {
+    (hooks.useAllTasks as jest.Mock).mockReturnValue({
+      data: []
+    });
+
+    providersRender(<Tasks />);
+
+    expect(screen.getByText('No tasks found')).toBeInTheDocument();
+    expect(screen.getByText('There are currently no tasks.')).toBeInTheDocument();
+  });
+
+  it('shows filtered empty state when tasks exist but none match filters', () => {
+    (hooks.useAllTasks as jest.Mock).mockReturnValue({
+      data: [mockTasks[2]] // Only completed task
+    });
+
+    providersRender(<Tasks />);
+
+    expect(screen.getByText('No results found')).toBeInTheDocument();
+    expect(screen.getByText('There are no tasks matching your filters.')).toBeInTheDocument();
+  });
+
+  it('shows filter count in button when filters are active', () => {
+    providersRender(<Tasks />);
+
+    const filterButton = screen.getByText(/Sort & Filter/);
+    expect(filterButton.textContent).toContain('(1)'); // Has status filter by default
+  });
+});


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

https://ndtp.atlassian.net/browse/DPAV-1511

## Description
- Add GET /api/tasks to return all tasks in useTasks hook
- Rename old Tasks component to IncidentTasks, new Tasks page called this instead
- Extract notifications list component to new DataList component
- Move inputs from left to right on Sort & Filter component
- Add applied filter count to sub-entries in the Sort & Filter component
- Export countActive from SortFilter to allow showing applied filters outside of component

## How Has This Been Tested?

Manually via UI & unit tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.