### PR TITLE
feat(DPAV-1432) Wire up Tasks widget to Tasks hook

### DIFF
--- a/frontend/src/components/Widgets/TaskWidget.tsx
+++ b/frontend/src/components/Widgets/TaskWidget.tsx
@@ -3,16 +3,29 @@
 // and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
 
 import { Box, Typography, Button } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import { Task } from 'common/Task';
 import WidgetBase from './WidgetBase';
-import { logInfo } from '../../utils/logger';
+import { useAllTasks } from '../../hooks/useTasks';
 
 const TasksWidget = () => {
-  const toDoCount = 0;
-  const inProgressCount = 0;
+  const { data: tasks, isLoading } = useAllTasks();
+  const navigate = useNavigate();
 
-  const onNavigateToDo = () => logInfo('Clicked To do');
-  const onNavigateInProgress = () => logInfo('Clicked In progress');
-  const onNavigateTasksHeader = () => logInfo('Clicked tasks header');
+  const toDoCount = tasks?.filter((t: Task) => t.status === 'ToDo').length ?? 0;
+  const inProgressCount = tasks?.filter((t: Task) => t.status === 'InProgress').length ?? 0;
+
+  const onNavigateToDo = () => navigate('/tasks?mine=true&status=ToDo');
+  const onNavigateInProgress = () => navigate('/tasks?mine=true&status=InProgress');
+  const onNavigateTasksHeader = () => navigate('/tasks?mine=true');
+
+  if (isLoading) {
+    return (
+      <WidgetBase title="Your tasks">
+        <Typography>Loading tasks…</Typography>
+      </WidgetBase>
+    );
+  }
 
   const renderCount = (count: number, onClick: () => void) => {
     const isActive = count > 0;

--- a/frontend/src/components/__tests__/Widgets/TaskWidget.test.tsx
+++ b/frontend/src/components/__tests__/Widgets/TaskWidget.test.tsx
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+// and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { Task } from 'common/Task';
+import { useNavigate } from 'react-router-dom';
+import TasksWidget from '../../Widgets/TaskWidget';
+import { useAllTasks } from '../../../hooks/useTasks';
+
+jest.mock('../../../hooks/useTasks');
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: jest.fn()
+}));
+
+describe('TasksWidget', () => {
+  const mockNavigate = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
+  });
+
+  it('renders loading state', () => {
+    (useAllTasks as jest.Mock).mockReturnValue({
+      data: undefined,
+      isLoading: true
+    });
+
+    render(<TasksWidget />);
+
+    expect(screen.getByText(/your tasks/i)).toBeInTheDocument();
+    expect(screen.getByText(/loading tasks/i)).toBeInTheDocument();
+  });
+
+  it('renders correct counts for ToDo and InProgress tasks', () => {
+    const mockTasks: Partial<Task>[] = [
+      { id: '1', status: 'ToDo' },
+      { id: '2', status: 'ToDo' },
+      { id: '3', status: 'InProgress' }
+    ];
+
+    (useAllTasks as jest.Mock).mockReturnValue({
+      data: mockTasks,
+      isLoading: false
+    });
+
+    render(<TasksWidget />);
+
+    expect(screen.getByRole('button', { name: '2' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '1' })).toBeInTheDocument();
+
+    expect(screen.getByRole('button', { name: /view to do tasks/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /view in progress tasks/i })).toBeInTheDocument();
+  });
+
+  it('navigates to correct URL when ToDo count clicked', () => {
+    const mockTasks: Partial<Task>[] = [{ id: '1', status: 'ToDo' }];
+
+    (useAllTasks as jest.Mock).mockReturnValue({
+      data: mockTasks,
+      isLoading: false
+    });
+
+    render(<TasksWidget />);
+
+    fireEvent.click(screen.getByRole('button', { name: '1' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/tasks?mine=true&status=ToDo');
+  });
+
+  it('navigates to correct URL when InProgress count clicked', () => {
+    const mockTasks: Partial<Task>[] = [{ id: '1', status: 'InProgress' }];
+
+    (useAllTasks as jest.Mock).mockReturnValue({
+      data: mockTasks,
+      isLoading: false
+    });
+
+    render(<TasksWidget />);
+
+    fireEvent.click(screen.getByRole('button', { name: '1' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/tasks?mine=true&status=InProgress');
+  });
+
+  it('navigates to tasks when header arrow clicked', () => {
+    (useAllTasks as jest.Mock).mockReturnValue({
+      data: [],
+      isLoading: false
+    });
+
+    render(<TasksWidget />);
+
+    fireEvent.click(screen.getByRole('button', { name: /open tasks/i }));
+    expect(mockNavigate).toHaveBeenCalledWith('/tasks?mine=true');
+  });
+});

--- a/frontend/src/hooks/useTasks.ts
+++ b/frontend/src/hooks/useTasks.ts
@@ -18,14 +18,14 @@ export const useTasks = (incidentId?: string) =>
     queryKey: [`incident/${incidentId}/tasks`],
     queryFn: () => get(`/incident/${incidentId}/tasks`),
     enabled: !!incidentId,
-    staleTime: 5 * 60 * 1000 // 5 minutes
+    staleTime: 10_000 // 10 seconds
   });
 
 export const useAllTasks = () =>
   useQuery<Task[]>({
     queryKey: ['tasks'],
     queryFn: () => get('/tasks'),
-    staleTime: 5 * 60 * 1000 // 5 minutes
+    staleTime: 10_000 // 10 seconds
   });
 
 export const useUpdateTaskStatus = (incidentId?: string) => {

--- a/frontend/src/pages/__tests__/Tasks.test.tsx
+++ b/frontend/src/pages/__tests__/Tasks.test.tsx
@@ -89,7 +89,11 @@ jest.mock('../../hooks', () => ({
   })),
   useAllTasks: jest.fn(() => ({
     data: mockTasks
-  }))
+  })),
+  useAuth: jest.fn(() => ({
+    user: { current: { username: 'testUser', displayName: 'Test User', email: 'test@test.com', groups: [] } },
+    logout: jest.fn()
+  })),
 }));
 
 describe('Tasks Page', () => {


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
- Gets InProgress and ToDo counts from live Task counts
- Navigates to Tasks page with relevant filter by clicking header, ToDo, InProgress
- Modifies staletime for Tasks to 10 seconds to avoid weird situations where I get a notification but then have to wait 5 minutes for the actual Task to appear

## Description
As above

## How Has This Been Tested?
Tested and verified locally

## Screenshots (if appropriate):
<img width="433" height="203" alt="image" src="https://github.com/user-attachments/assets/8bb94c5c-6ba5-4da9-825a-27243b6eb70d" />

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.