### PR TITLE
fix(DPAV-1446): add version number to settings page

### DIFF
--- a/.github/workflows/frontend-cd-push-to-ECR.yml
+++ b/.github/workflows/frontend-cd-push-to-ECR.yml
@@ -79,6 +79,8 @@ jobs:
         run: npm ci
 
       - name: Build Frontend
+        env:
+          VITE_LISA_VERSION: ${{ inputs.version }}
         run: |
           npm run build
 

--- a/frontend/src/components/AppVersion.tsx
+++ b/frontend/src/components/AppVersion.tsx
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+// and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
+
+import { Box, Typography } from "@mui/material";
+
+const AppVersion = () => {
+  const version = import.meta.env.VITE_LISA_VERSION || 'N/A';
+
+  return (
+    <Box className="version">
+      <Typography variant="body2">Version {version}</Typography>
+    </Box>
+  );
+}
+
+export default AppVersion;

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -9,6 +9,7 @@ import { PageTitle } from '../components';
 import PageWrapper from '../components/PageWrapper';
 import { useAuth } from '../hooks';
 import { isAdmin } from '../utils/userRoles';
+import AppVersion from '../components/AppVersion';
 
 const Settings = () => {
   const { user } = useAuth()
@@ -80,6 +81,7 @@ const Settings = () => {
             </List>
           </CardContent>
         </Card>
+        <AppVersion />
       </PageWrapper>
     </>
   )


### PR DESCRIPTION
## Sensitive Credential Checks
- [X] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

## Motivation and Context
Adds application version number to settings page.

## Description
Adds application version number to settings page, sourced from build environment variable at packaging time.

## How Has This Been Tested?
Tested locally and to be tested via remote GH Action.

## Screenshots (if appropriate):
<img width="816" height="512" alt="image" src="https://github.com/user-attachments/assets/b43edca1-28f1-4425-ba23-27df83cc4274" />

## Checklist:
- [X] It contains only changes required by issue (does not contain other PR)
- [X] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.