### PR TITLE
fix(NON-REQ): run nginx as non-root user

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,5 +1,5 @@
 # FROM nginx as runner
-FROM nginx:1.29.0
+FROM nginxinc/nginx-unprivileged:1.29.0-alpine-perl
 
 # Copy the built files from the builder stage to the runner stage
 COPY frontend/dist /usr/share/nginx/html

--- a/deployment/k8s/transparent-proxy/base/deployment.yaml
+++ b/deployment/k8s/transparent-proxy/base/deployment.yaml
@@ -39,6 +39,6 @@ spec:
               memory: "256Mi"
               ephemeral-storage: "2Gi"
           ports:
-            - containerPort: 80
+            - containerPort: 8080
               protocol: TCP
       restartPolicy: Always

--- a/deployment/k8s/webapp/base/deployment.yaml
+++ b/deployment/k8s/webapp/base/deployment.yaml
@@ -40,6 +40,6 @@ spec:
               memory: "256Mi"
               ephemeral-storage: "2Gi"
           ports:
-            - containerPort: 80
+            - containerPort: 8080
               protocol: TCP
       restartPolicy: Always

--- a/transparent-proxy/Dockerfile
+++ b/transparent-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.29.0
+FROM nginxinc/nginx-unprivileged:1.29.0-alpine-perl
 
 RUN ["rm", "/etc/nginx/conf.d/default.conf"]
 


### PR DESCRIPTION
## Sensitive Credential Checks
- [X] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

## Motivation and Context
Moves to use of official NGINX unprivileged image to avoid container identity running as root.

## Description
Moves to use of official NGINX unprivileged image to avoid container identity running as root, and maps K8s resources to container port 8080.

## How Has This Been Tested?
To be tested in remote deployment environment.

## Checklist:
- [X] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.