### PR TITLE
feature(NON-REQ): convert to unprivileged NGINX image

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,5 +1,5 @@
 # FROM nginx as runner
-FROM nginx:1.29.0
+FROM nginxinc/nginx-unprivileged:1.29-alpine3.22
 
 # Copy the built files from the builder stage to the runner stage
 COPY frontend/dist /usr/share/nginx/html

--- a/deployment/k8s/transparent-proxy/base/deployment.yaml
+++ b/deployment/k8s/transparent-proxy/base/deployment.yaml
@@ -25,7 +25,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /transparent-proxy/health
-              port: 80
+              port: 8080
             failureThreshold: 5
             periodSeconds: 30
             timeoutSeconds: 10
@@ -39,6 +39,6 @@ spec:
               memory: "256Mi"
               ephemeral-storage: "2Gi"
           ports:
-            - containerPort: 80
+            - containerPort: 8080
               protocol: TCP
       restartPolicy: Always

--- a/deployment/k8s/transparent-proxy/base/service.yaml
+++ b/deployment/k8s/transparent-proxy/base/service.yaml
@@ -10,6 +10,6 @@ spec:
   ports:
     - name: "80"
       port: 80
-      targetPort: 80
+      targetPort: 8080
   selector:
     io.kompose.service: lisa-transparent-proxy

--- a/deployment/k8s/webapp/base/deployment.yaml
+++ b/deployment/k8s/webapp/base/deployment.yaml
@@ -20,14 +20,14 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: 80
+              port: 8080
             failureThreshold: 5
             periodSeconds: 30
             timeoutSeconds: 20
           readinessProbe:
               httpGet:
                 path: /
-                port: 80
+                port: 8080
               failureThreshold: 5
               periodSeconds: 30
               timeoutSeconds: 20
@@ -40,6 +40,6 @@ spec:
               memory: "256Mi"
               ephemeral-storage: "2Gi"
           ports:
-            - containerPort: 80
+            - containerPort: 8080
               protocol: TCP
       restartPolicy: Always

--- a/deployment/k8s/webapp/base/service.yaml
+++ b/deployment/k8s/webapp/base/service.yaml
@@ -11,6 +11,6 @@ spec:
   ports:
     - name: "80"
       port: 80
-      targetPort: 80
+      targetPort: 8080
   selector:
     io.kompose.service: lisa

--- a/transparent-proxy/Dockerfile
+++ b/transparent-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.29.0
+FROM nginxinc/nginx-unprivileged:1.29-alpine3.22
 
 RUN ["rm", "/etc/nginx/conf.d/default.conf"]
 


### PR DESCRIPTION
## Sensitive Credential Checks
- [X] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

## Motivation and Context
Moves to official unprivileged NGINX image for web app and transparent proxy.

## Description
Moves to official unprivileged NGINX image for web app and transparent proxy. Also updates port bindings for routing to revised 8080 port.

## How Has This Been Tested?
To be tested in remote deployment environment.

## Checklist:
- [X] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.