### PR TITLE
feat(DPAV-1572): Create log entry after task creation

### DIFF
--- a/backend/src/services/logEntry/utils/details/extractDetails.ts
+++ b/backend/src/services/logEntry/utils/details/extractDetails.ts
@@ -10,6 +10,10 @@ export function extractDetails(entry: LogEntry, entryIdNode: unknown): Array<unk
 
   const triples: unknown[] = [];
 
+  if (entry.details.createdTaskId) {
+    triples.push([entryIdNode, ns.lisa.hasCreatedTask, ns.data(entry.details.createdTaskId)]);
+  }
+    
   if (entry.details.changedTaskId) {
     triples.push([entryIdNode, ns.lisa.hasModifiedTask, ns.data(entry.details.changedTaskId)]);
   }

--- a/backend/src/services/logEntry/utils/details/parseDetails.ts
+++ b/backend/src/services/logEntry/utils/details/parseDetails.ts
@@ -15,6 +15,10 @@ export async function parseDetails(
   for (const result of results) {
     const entryId = nodeValue(result.entryId.value);
 
+    const createdTaskId = result?.createdTaskId?.value
+      ? nodeValue(result?.createdTaskId?.value)
+      : undefined;
+    const createdTaskName = result?.createdTaskName?.value;    
     const changedTaskId = result?.changedTaskId?.value
       ? nodeValue(result?.changedTaskId?.value)
       : undefined;
@@ -29,6 +33,8 @@ export async function parseDetails(
 
     if (!detailsByEntry.has(entryId)) {
       const details: LogEntryChangeDetails = {
+        createdTaskId,
+        createdTaskName,        
         changedTaskId,
         changedTaskName,
         changedAssignee,

--- a/backend/src/services/logEntry/utils/select/details.ts
+++ b/backend/src/services/logEntry/utils/select/details.ts
@@ -14,6 +14,10 @@ export function details(incidentId: string) {
     clause: [
       [ns.data(incidentId), ns.lisa.hasLogEntry, '?entryId'],
       optional([
+        ['?entryId', ns.lisa.hasCreatedTask, '?createdTaskId'],
+        ['?createdTaskId', ns.ies.hasName, '?createdTaskName']
+      ]),      
+      optional([
         ['?entryId', ns.lisa.hasModifiedTask, '?changedTaskId'],
         ['?changedTaskId', ns.ies.hasName, '?changedTaskName']
       ]),

--- a/common/LogEntryChangeDetails.ts
+++ b/common/LogEntryChangeDetails.ts
@@ -6,6 +6,8 @@ import { Static, Record, String, Optional } from 'runtypes';
 import { TaskStatus } from './Task';
 
 export const LogEntryChangeDetails = Record({
+  createdTaskId: Optional(String), // Only applicable to type TaskCreated
+  createdTaskName: Optional(String), // Only applicable to type TaskCreated  
   changedAssignee: Optional(String), // Only applicable to type ChangeTaskAssignee
   changedStatus: Optional(TaskStatus), // Only applicable to type ChangeTaskStatus
   changedTaskName: Optional(String), // Only applicable to type ChangeTaskStatus/ChangeTaskAssignee

--- a/common/LogEntryType.ts
+++ b/common/LogEntryType.ts
@@ -20,6 +20,7 @@ export const LogEntryType = Union(
   Literal('ShiftHandover'),
   Literal('ChangeStage'),
   Literal('SetIncidentInformation'),
+  Literal('TaskCreated'),  
   Literal('ChangeTaskAssignee'),
   Literal('ChangeTaskStatus'),
   Literal('FormSubmitted')

--- a/common/LogEntryTypes/TaskCreated.ts
+++ b/common/LogEntryTypes/TaskCreated.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+// and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
+
+import { type LogEntryTypesDictItem } from './types';
+
+export const TaskCreated: LogEntryTypesDictItem = {
+  label: 'Task created',
+  colour: 'yellow',
+  fields: () => [],
+  noContent: true,
+  unselectable: () => true
+};

--- a/common/LogEntryTypes/index.ts
+++ b/common/LogEntryTypes/index.ts
@@ -19,6 +19,7 @@ import { SetIncidentInformation } from './SetIncidentInformation';
 import { ChangeTaskStatus } from './ChangeTaskStatus';
 import { ChangeTaskAssignee } from './ChangeTaskAssignee';
 import { FormSubmitted } from './FormSubmitted';
+import { TaskCreated } from './TaskCreated';
 
 export const LogEntryTypes: LogEntryTypesDict = {
   AvianFlu,
@@ -35,6 +36,7 @@ export const LogEntryTypes: LogEntryTypesDict = {
   SituationReport,
   ChangeStage,
   SetIncidentInformation,
+  TaskCreated,  
   ChangeTaskStatus,
   ChangeTaskAssignee,
   FormSubmitted

--- a/frontend/src/components/EntryList/Details/TaskCreated.tsx
+++ b/frontend/src/components/EntryList/Details/TaskCreated.tsx
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+// and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
+
+import { type LogEntry } from 'common/LogEntry';
+import { Box, Typography } from '@mui/material';
+import { Link } from 'react-router-dom';
+
+interface Props {
+  entry: LogEntry;
+}
+export default function TaskCreated({ entry }: Readonly<Props>) {
+  if (!entry.details) {
+    return null;
+  }
+
+  const { createdTaskName: taskName, createdTaskId: taskId } = entry.details;
+
+  return (
+    <Box
+      display="flex"
+      flexDirection="row"
+      justifyContent="left"
+      alignItems="center"
+      component="ul"
+      gap={1}
+      sx={{ width: '100%', mb: 2 }}
+    >
+      <Typography variant="body1" fontWeight="bold">
+        Task name:
+      </Typography>
+      <Typography
+        component={Link}
+        to={`/tasks/${entry.incidentId}#${taskId}`}
+        color="primary"
+        fontWeight="bold"
+      >
+        {taskName}
+      </Typography>
+    </Box>
+  );
+}

--- a/frontend/src/components/EntryList/Details/index.tsx
+++ b/frontend/src/components/EntryList/Details/index.tsx
@@ -12,6 +12,7 @@ import SetInformation from './SetInformation';
 import ChangeTaskStatus from './ChangeTaskStatus';
 import ChangeTaskAssignee from './ChangeTaskAssignee';
 import FormSubmitted from './FormSubmitted';
+import TaskCreated from './TaskCreated';
 
 interface Props {
   entry: LogEntry;
@@ -27,6 +28,9 @@ export default function Details({ entry, onContentClick }: Readonly<Props>) {
     case 'SetIncidentInformation':
       detail = <SetInformation entry={entry} />;
       break;
+    case 'TaskCreated':
+      detail = <TaskCreated entry={entry} />;
+      break;      
     case 'ChangeTaskStatus':
       detail = <ChangeTaskStatus entry={entry} />;
       break;

--- a/frontend/src/pages/CreateTask.tsx
+++ b/frontend/src/pages/CreateTask.tsx
@@ -19,7 +19,7 @@ export default function CreateTaskPage() {
   const navigate = useNavigate();
   const { data: incidents } = useIncidents();
   const { users } = useUsers();
-  const createTask = useCreateTask({ author: user.current! });
+  const createTask = useCreateTask({ author: user.current!, incidentId });
   const postToast = useToast();
 
   const incident: Incident | undefined = useMemo(

--- a/frontend/src/utils/Task/updateLogEntries.ts
+++ b/frontend/src/utils/Task/updateLogEntries.ts
@@ -40,3 +40,20 @@ export function createLogEntryFromTaskAssigneeUpdate(taskId : string, assigneeNa
   
   return logEntry;
 }
+
+export function createLogEntryFromTaskCreation(taskId: string, taskName: string, incidentId: string, entry?: Partial<LogEntry>): Partial<LogEntry> {
+  const logEntry: Partial<LogEntry> = entry ?? {
+    type: 'TaskCreated',
+    incidentId,
+    dateTime: new Date().toISOString(),
+    content: {},
+    fields: [],
+    sequence: createSequenceNumber(),
+    details: {
+      createdTaskId: taskId,
+      createdTaskName: taskName
+    }
+  };
+  
+  return logEntry;
+}


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

Adds a log entry when creating a task, like we do when changing the status or assignee.

https://ndtp.atlassian.net/browse/DPAV-1572

## Description

Add new TaskCreated  log entry type and handling

## How Has This Been Tested?

Locally

## Screenshots (if appropriate):

<img width="425" height="355" alt="Screenshot 2025-08-19 at 09 23 48" src="https://github.com/user-attachments/assets/ef11eb2a-a270-4ffc-9c2e-3bca0da66a00" />


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.