### PR TITLE
fix(DPAV-1447): add no result content when users not matched to filters

### DIFF
--- a/frontend/src/pages/AdminUserList.tsx
+++ b/frontend/src/pages/AdminUserList.tsx
@@ -135,33 +135,52 @@ const AdminUserList = () => {
 
 
         <TableContainer component={Card} variant="outlined" sx={{ borderRadius: 2 }}>
-          <Table>
-            <TableHead>
-              <TableRow>
-                <TableCell sx={visuallyHidden}>User</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {visibleUsers.map((user) => (
-                <TableRow key={user.email}>
-                  <TableCell>
-                    <Typography
-                      variant="body1"
-                      color="primary"
-                      fontWeight="bold"
-                      component={Link}
-                      to={`/settings/user-profile?user=${encodeURIComponent(user.email || '')}`}
-                    >
-                      {user.displayName}
-                    </Typography>
-                    <Typography variant="body2" color="text.secondary">
-                      {user.email?.split('@')[1] || ''}
-                    </Typography>
-                  </TableCell>
+          {visibleUsers.length === 0 ? (
+            <Box
+              sx={{
+                display: 'flex',
+                padding: 4,
+                flexDirection: 'column',
+                alignItems: 'center',
+                color: 'text.secondary'
+              }}
+            >
+              <Typography variant="h6">
+                No results found
+              </Typography>
+              <Typography variant="body2">
+                There are no users matching your filters.
+              </Typography>
+            </Box>
+          ) : (
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell sx={visuallyHidden}>User</TableCell>
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+              </TableHead>
+              <TableBody>
+                {visibleUsers.map((user) => (
+                  <TableRow key={user.email}>
+                    <TableCell>
+                      <Typography
+                        variant="body1"
+                        color="primary"
+                        fontWeight="bold"
+                        component={Link}
+                        to={`/settings/user-profile?user=${encodeURIComponent(user.email || '')}`}
+                      >
+                        {user.displayName}
+                      </Typography>
+                      <Typography variant="body2" color="text.secondary">
+                        {user.email?.split('@')[1] || ''}
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
         </TableContainer>
 
         <SortAndFilter


### PR DESCRIPTION
## Sensitive Credential Checks
- [X] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

## Motivation and Context
Adds no result messaging to user search for consistency with incident and task filtering.

## Description
Adds content to user search if no results are found due to filters applied.

## How Has This Been Tested?
Tested locally (desktop) and remotely on mobile.

## Screenshots (if appropriate):
<img width="1857" height="291" alt="image" src="https://github.com/user-attachments/assets/6589cda9-3e85-4a37-9a5b-0285290ae508" />

## Checklist:
- [X] It contains only changes required by issue (does not contain other PR)
- [X] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.