### PR TITLE
bugfix(NON-REQ): exclude inactive users from selects

### DIFF
--- a/frontend/src/components/AddEntry/index.tsx
+++ b/frontend/src/components/AddEntry/index.tsx
@@ -13,7 +13,7 @@ import { type Incident } from 'common/Incident';
 import { type Location as LocationType } from 'common/Location';
 import { type LogEntry } from 'common/LogEntry';
 import { type Attachment } from 'common/Attachment';
- 
+
 import { LogEntryTypes } from 'common/LogEntryTypes';
 import { type Mentionable } from 'common/Mentionable';
 import { useUsers } from '../../hooks';
@@ -85,7 +85,7 @@ const AddEntry = ({
       ...(getSortedEntriesWithDisplaySequence(false, entries)?.map((e) =>
         Format.mentionable.entry(e)
       ) ?? []),
-      ...(users?.map(Format.mentionable.user) ?? []),
+      ...(users?.filter((user) => user.displayName).map(Format.mentionable.user) ?? []),
       ...selectedFiles.map((file) =>
         Format.mentionable.attachment({ name: file.name, type: 'File' })
       ),

--- a/frontend/src/components/AddEntry/index.tsx
+++ b/frontend/src/components/AddEntry/index.tsx
@@ -85,7 +85,10 @@ const AddEntry = ({
       ...(getSortedEntriesWithDisplaySequence(false, entries)?.map((e) =>
         Format.mentionable.entry(e)
       ) ?? []),
-      ...(users?.filter((user) => user.displayName).map(Format.mentionable.user) ?? []),
+      ...(users
+        ?.filter((user) => user.displayName)
+        .sort((a, b) => a.displayName.localeCompare(b.displayName))
+        .map(Format.mentionable.user) ?? []),
       ...selectedFiles.map((file) =>
         Format.mentionable.attachment({ name: file.name, type: 'File' })
       ),

--- a/frontend/src/components/Task/TaskInputContainer.tsx
+++ b/frontend/src/components/Task/TaskInputContainer.tsx
@@ -114,6 +114,7 @@ export const TaskInputContainer = ({
   const assigneeOptions = useMemo(() => {
     return users
       ?.filter((user) => user.displayName)
+      .sort((a, b) => a.displayName.localeCompare(b.displayName))
       .map((user) => ({ value: user.username, label: user.displayName }));
   }, [users]);
 

--- a/frontend/src/components/Task/TaskInputContainer.tsx
+++ b/frontend/src/components/Task/TaskInputContainer.tsx
@@ -34,7 +34,13 @@ const fieldConfigs = {
   sketch: { heading: 'Add sketch', required: false, supportedOffline: true }
 };
 
-export const TaskInputContainer = ({ users, incidentId, onSubmit, onCancel, isSubmitting = false }: Readonly<Props>) => {
+export const TaskInputContainer = ({
+  users,
+  incidentId,
+  onSubmit,
+  onCancel,
+  isSubmitting = false
+}: Readonly<Props>) => {
   const [level, setLevel] = useState<number>(0);
   const [activeField, setActiveField] = useState<FieldType | null>(null);
 
@@ -105,7 +111,11 @@ export const TaskInputContainer = ({ users, incidentId, onSubmit, onCancel, isSu
     setSelectedFiles((prev) => prev.filter((f) => f.name !== name));
   };
 
-  const assigneeOptions = users?.map((user) => ({ value: user.username, label: user.displayName }));
+  const assigneeOptions = useMemo(() => {
+    return users
+      ?.filter((user) => user.displayName)
+      .map((user) => ({ value: user.username, label: user.displayName }));
+  }, [users]);
 
   const handleSubmit = () => {
     const validationErrors = validateTask(task);

--- a/frontend/src/pages/AdminUserList.tsx
+++ b/frontend/src/pages/AdminUserList.tsx
@@ -39,19 +39,19 @@ const AdminUserList = () => {
 
   const visibleUsers = useMemo(() => {
     if (!users) return [];
-  
+
     const base = users.filter(u => u.displayName?.trim()); // exclude missing names
-  
+
     const v = queryState.values;
     const searchTerm = ((v.search as string) ?? '').trim().toLowerCase();
-  
+
     const filtered = base.filter((user) => {
       if (!searchTerm) return true;
       if (user.email?.toLowerCase().includes(searchTerm)) return true;
       if (user.displayName.toLowerCase().includes(searchTerm)) return true;
       return false;
     });
-  
+
     const sorted = [...filtered].sort((a, b) => {
       const key = queryState.sort?.by;
       switch (key) {
@@ -67,7 +67,7 @@ const AdminUserList = () => {
           return a.displayName.localeCompare(b.displayName);
       }
     });
-  
+
     return sorted;
   }, [users, queryState.sort?.by, queryState.values]);
 

--- a/frontend/src/pages/CreateLogEntry.tsx
+++ b/frontend/src/pages/CreateLogEntry.tsx
@@ -65,7 +65,7 @@ export const CreateLogEntry = () => {
       ...(getSortedEntriesWithDisplaySequence(false, logEntries ?? [])?.map((e) =>
         Format.mentionable.entry(e)
       ) ?? []),
-      ...(users?.map(Format.mentionable.user) ?? []),
+      ...(users?.filter((user) => user.displayName).map(Format.mentionable.user) ?? []),
       ...selectedFiles.map((file) =>
         Format.mentionable.attachment({ name: file.name, type: 'File' })
       ),

--- a/frontend/src/pages/CreateLogEntry.tsx
+++ b/frontend/src/pages/CreateLogEntry.tsx
@@ -65,7 +65,10 @@ export const CreateLogEntry = () => {
       ...(getSortedEntriesWithDisplaySequence(false, logEntries ?? [])?.map((e) =>
         Format.mentionable.entry(e)
       ) ?? []),
-      ...(users?.filter((user) => user.displayName).map(Format.mentionable.user) ?? []),
+      ...(users
+        ?.filter((user) => user.displayName)
+        .sort((a, b) => a.displayName.localeCompare(b.displayName))
+        .map(Format.mentionable.user) ?? []),
       ...selectedFiles.map((file) =>
         Format.mentionable.attachment({ name: file.name, type: 'File' })
       ),

--- a/frontend/src/pages/IncidentTask.tsx
+++ b/frontend/src/pages/IncidentTask.tsx
@@ -99,7 +99,11 @@ const TaskContent = ({ header, task, users }: Readonly<TaskContentProps>) => {
           <GridListItem title="Task description" text={task.description} />
           <GridListItem title="Assigned by" text={task.author.displayName} />
           {canUpdateTask ? (
-            <AssigneeSelector value={task.assignee} availableValues={users?.filter((u) => u.username !== user.current?.username)} onChange={onChangeAssignee} />
+            <AssigneeSelector
+              value={task.assignee}
+              availableValues={users?.filter((u) => u.displayName && u.username !== user.current?.username) ?? []}
+              onChange={onChangeAssignee}
+            />
           ) : (
             <GridListItem title="Assigned to" text={task.assignee.displayName} />
           )}

--- a/frontend/src/pages/IncidentTask.tsx
+++ b/frontend/src/pages/IncidentTask.tsx
@@ -101,7 +101,9 @@ const TaskContent = ({ header, task, users }: Readonly<TaskContentProps>) => {
           {canUpdateTask ? (
             <AssigneeSelector
               value={task.assignee}
-              availableValues={users?.filter((u) => u.displayName && u.username !== user.current?.username) ?? []}
+              availableValues={users
+                ?.filter((u) => u.displayName && u.username !== user.current?.username)
+                .sort((a, b) => a.displayName.localeCompare(b.displayName)) ?? []}
               onChange={onChangeAssignee}
             />
           ) : (


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

Users that haven't accepted the invite yet and set their name were showing up in user pickers.

## Description

Excludes inactive users (those that haven't set their name yet) from
pickers. In the future we should expose the state of a user, but this
will require larger changes to the identity api and backend to pass
this through.

## How Has This Been Tested?

Locally

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.