### PR TITLE
fix(NON-REQ) Redirect to login after 403/401 on ping

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -19,37 +19,18 @@ import OnlineProvider from './providers/OnlineProvider';
 // Styles
 import './App.scss';
 import theme from './theme';
-
-interface LogoutLinks {
-  oAuthLogoutUrl: string;
-  redirect: string;
-  landingPageUrl: string;
-}
+import { primeLandingUrl, redirectToLanding } from './utils/authRedirect';
 
 const persister = createSyncStoragePersister({
   storage: window.localStorage
 });
 
-let cachedLandingPageUrl: string | null = null;
-const fetchLandingPageUrl = async (): Promise<void> => {
-  try {
-    const response = await fetch('/api/auth/logout-links');
-    if (response.ok) {
-      const logoutLinks: LogoutLinks = await response.json();
-      cachedLandingPageUrl = logoutLinks.landingPageUrl;
-    }
-  } catch (error) {
-    console.warn('Failed to fetch logout links config:', error);
-  }
-};
 
 const onError = async (error: FetchError) => {
   if (error.status === 302) {
     document.location = error.redirectUrl!;
   } else if (error.status === 401 || error.status === 403) {
-    if (cachedLandingPageUrl) {
-      document.location = cachedLandingPageUrl;
-    }
+    redirectToLanding();
   }
 };
 
@@ -78,4 +59,4 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   </PersistQueryClientProvider>
 );
 
-fetchLandingPageUrl();
+primeLandingUrl();

--- a/frontend/src/providers/OnlineProvider.tsx
+++ b/frontend/src/providers/OnlineProvider.tsx
@@ -5,6 +5,7 @@
 import { type ReactNode, useEffect, useMemo, useState } from 'react';
 import { onlineManager } from '@tanstack/react-query';
 import { OnlineContext } from '../context/OnlineContext';
+import { redirectToLanding } from '../utils/authRedirect';
 
 const PING_INTERVAL_MS = 2500; // polls every 2.5s
 const PING_URL = '/api/ping';
@@ -30,6 +31,12 @@ const OnlineProvider = ({ children }: Readonly<OnlineProviderProps>) => {
           method: 'HEAD',
           cache: 'no-store'
         });
+
+        if (response.status === 401 || response.status === 403) {
+          redirectToLanding();
+          return;
+        }
+
         onlineManager.setOnline(response.ok);
       } catch {
         onlineManager.setOnline(false);

--- a/frontend/src/utils/authRedirect.ts
+++ b/frontend/src/utils/authRedirect.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+// and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
+
+import { logError } from "./logger";
+
+export const AUTH_REDIRECT_STORAGE_KEY = 'landingPageUrl';
+
+let landingUrl: string | null = null;
+
+export function setLandingUrl(url: string) {
+  landingUrl = url;
+  try {
+    localStorage.setItem(AUTH_REDIRECT_STORAGE_KEY, url);
+  } catch(err) {
+    logError('Unable to set landing url', err)
+  }
+}
+
+export function getLandingUrl(): string | null {
+  try {
+    return landingUrl ?? localStorage.getItem(AUTH_REDIRECT_STORAGE_KEY);
+  } catch {
+    return landingUrl;
+  }
+}
+
+export function redirectToLanding(fallback: string = '/') {
+  const url = getLandingUrl() ?? fallback;
+  window.location.replace(url);
+}
+
+export async function primeLandingUrl(): Promise<void> {
+  try {
+    const res = await fetch('/api/auth/logout-links', {
+      cache: 'no-store',
+      credentials: 'include'
+    });
+    if (res.ok) {
+      const data = await res.json() as { landingPageUrl?: string };
+      if (data?.landingPageUrl) setLandingUrl(data.landingPageUrl);
+    }
+  } catch (err) {
+    logError('Unable to prime landing url', err)
+  }
+}


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
Currently LISA is not recognising and reacting when a session expires, despite APIs returning a 403/401 status code.

## Description
As part of the ping workflow, as soon as a 401 or 403 is detected from an API ping, the user is immediately redirected to the login page.

## How Has This Been Tested?
Tested locally but needs deploying to test fully

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.