### PR TITLE
feat(NON-REQ) Inline selectors should be wider

### DIFF
--- a/frontend/src/components/InlineSelectors/BaseInlineSelector.tsx
+++ b/frontend/src/components/InlineSelectors/BaseInlineSelector.tsx
@@ -78,7 +78,28 @@ export default function BaseInlineSelector<T>({
           {valueNode}
         </Box>
 
-        <Menu id={menuId} anchorEl={anchorEl} open={open} onClose={handleClose}>
+        <Menu
+          id={menuId}
+          anchorEl={anchorEl}
+          open={open}
+          onClose={handleClose}
+          marginThreshold={12}
+          anchorOrigin={{ horizontal: 'left',  vertical: 'bottom' }}
+          transformOrigin={{ horizontal: 'left', vertical: 'top' }}
+          slotProps={{
+            paper: {
+              sx: {
+                width: '95dvw',
+                maxWidth: '95dvw',
+                maxHeight: 'calc(100dvh - 72px)',
+                overflowY: 'auto',
+              },
+            },
+            list: {
+              sx: { px: 2 },
+            },
+          }}
+        >
           {options.map((opt) => {
             const { icon, label } = renderOption(opt);
             return (


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
Make inline selector dropdowns wider to facilitate thumb scrolling on mobile.

## Description
As above

## How Has This Been Tested?
Tested and verified locally

## Screenshots (if appropriate):
<img width="266" height="71" alt="image" src="https://github.com/user-attachments/assets/bfdea5c4-6213-4781-925f-80a606ac463e" />
<img width="265" height="82" alt="image" src="https://github.com/user-attachments/assets/9607c6e3-dbcf-4c77-a43b-19157b7b5c55" />
<img width="260" height="153" alt="image" src="https://github.com/user-attachments/assets/9ce54414-0773-460c-a2ec-0e93647077d0" />

A longer list still gives space around the top for the user to click off:

<img width="263" height="373" alt="image" src="https://github.com/user-attachments/assets/049122dd-e434-411f-baf3-5e9dec8fc9c3" />


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.