### PR TITLE
Feature: DPAV-1295: Entity Input Confirm Button

### DIFF
--- a/backend/src/services/task/get.ts
+++ b/backend/src/services/task/get.ts
@@ -36,10 +36,10 @@ async function mapResultsToTasks(
       taskMap.set(taskId, {
         id: taskId,
         name: result.taskName.value,
-        description: result.description.value,
+        description: result.description?.value,
         content: {
-          text: result.contentText.value || result.description.value || '',
-          json: result.contentJSON.value || undefined
+          text: result.contentText?.value || result.description?.value || '',
+          json: result.contentJSON?.value || undefined
         },
         incidentId,
         author: {

--- a/frontend/src/components/AddEntry/EntryInputContainer.tsx
+++ b/frontend/src/components/AddEntry/EntryInputContainer.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, RefObject, useEffect, useMemo, useState } from 'react';
+import { RefObject, useCallback, useEffect, useMemo, useState } from 'react';
 import { Stage } from 'konva/lib/Stage';
 import { Incident } from 'common/Incident';
 import { LogEntry } from 'common/LogEntry';
@@ -10,19 +10,19 @@ import { Format, Validate } from '../../utils';
 import { EntityOptionData } from '../AddEntity/EntityOptions';
 import { EntityInputContainer, EntityInputContainerData } from '../AddEntity/EntityInputContainer';
 import { EntityOptionsContainer } from '../AddEntity/EntityOptionsContainer';
+import { useTemporaryState } from '../../hooks/useTemporaryState';
 import EntryContent from '../lexical/EntryContent';
 import { DateAndTimePicker } from '../DateAndTimePicker';
 import Location from './Location';
 import Files from './Files';
 import Sketch from './Sketch';
-import { Box, FormControl, Typography } from '@mui/material';
+import { Box, Button, FormControl, Typography } from '@mui/material';
 import { Form as CustomForm, FormDataProperty } from '../CustomForms/FormTemplates/types';
 import { Field } from 'common/Field';
 import { getFormTypes } from '../../utils/Form/getBaseLogEntryFields';
 import { getHazardLabel, getRelevantHazard } from 'common/LogEntryTypes/RiskAssessment/hazards';
 import { RelevantHazards } from 'common/LogEntryTypes/RiskAssessment/hazards/RelevantHazards';
 import { getFieldValue } from '../../utils/Form/getFieldValue';
-import { RelevantHazard } from 'common/LogEntryTypes/RiskAssessment/hazards/RelevantHazard';
 import { CommunicationMethod } from 'common/Fields/CommunicationMethod';
 import { LogEntryTypes } from 'common/LogEntryTypes';
 import { LogEntryType } from 'common/LogEntryType';
@@ -64,6 +64,19 @@ type Props = {
   onCancel: () => void;
 };
 
+type FieldType =
+| 'description'
+| 'dateAndTime'
+| 'location'
+| 'attachments'
+| 'sketch'
+| 'customForm'
+| 'siteRepDetails'
+| 'hazard'
+| 'comments'
+| 'riskAssessmentToReview'
+| 'formFields';
+
 export const EntryInputContainer = ({
   inputType,
   incident,
@@ -99,24 +112,54 @@ export const EntryInputContainer = ({
   );
   const [validationErrors, setValidationErrors] = useState<Array<ValidationError>>([]);
   const [customHeading, setCustomHeading] = useState<string>('');
-  const [addingDescription, setAddingDescription] = useState<boolean>(false);
-  const [addingDateAndTime, setAddingDateAndTime] = useState<boolean>(false);
-  const [addingLocation, setAddingLocation] = useState<boolean>(false);
-  const [addingAttachments, setAddingAttachments] = useState<boolean>(false);
-  const [addingSketch, setAddingSketch] = useState<boolean>(false);
+  const [activeField, setActiveField] = useState<FieldType | null>(null);
   const [selectingCustomForm, setSelectingCustomForm] = useState<boolean>(false);
-  const [addingCustomForm, setAddingCustomForm] = useState<boolean>(false);
-  const [addingSiteRepDetails, setAddingSiteRepDetails] = useState<boolean>(false);
-  const [addingHazard, setAddingHazard] = useState<boolean>(false);
   const [selectedHazardIndex, setSelectedHazardIndex] = useState<number>(0);
-  const [hazardValue, setHazardValue] = useState<string>();
-  const [hazardsOptionData, setHazardsOptionData] = useState<EntityOptionData[]>([]);
-  const [refreshHazardOptions, setRefreshHazardOptions] = useState<boolean>(false);
-  const [refreshRemoveHazardsCall, setRefreshRemoveHazardsCall] = useState<boolean>(false);
-  const [addingComments, setAddingComments] = useState<boolean>(false);
-  const [addingRiskAssessmentToReview, setAddingRiskAssessmentToReview] = useState<boolean>(false);
-  const [addingFormFields, setAddingFormFields] = useState<boolean>(false);
-  const [formField, setFormField] = useState<Field>();
+  const [selectedHazardType, setSelectedHazardType] = useState<string>();
+  const [activeFormField, setActiveFormField] = useState<Field>();
+  const [hazardChanges, setHazardChanges] = useState<Record<string, FieldValueType>>({});
+
+  type EditableState = {
+    entry: Partial<LogEntry>;
+    selectedFiles: Array<File>;
+    sketchLines: Array<SketchLine>;
+    customFormData: Array<FormDataProperty>;
+    activeFormField?: Field;
+    selectedHazardType?: string;
+    selectedHazardIndex: number;
+  };
+
+  const tempState = useTemporaryState<EditableState>();
+
+  const saveCurrentState = () => {
+    tempState.save({
+      entry,
+      selectedFiles,
+      sketchLines,
+      customFormData,
+      activeFormField,
+      selectedHazardType,
+      selectedHazardIndex
+    });
+    setHazardChanges({});
+  };
+
+  const getEntryWithHazardChanges = (): Partial<LogEntry> => {
+    return { ...entry, ...hazardChanges };
+  };
+
+
+  const applyHazardChangesToParent = () => {
+    Object.entries(hazardChanges).forEach(([key, value]) => {
+      onFieldChange(key, value, true);
+    });
+    setHazardChanges({});
+  };
+
+  const onHazardFieldChange = (id: string, value: FieldValueType) => {
+    setHazardChanges(prev => ({ ...prev, [id]: value }));
+  };
+
   const customForms: CustomForm[] = useMemo(
     () =>
       (inputType === 'form' &&
@@ -149,7 +192,39 @@ export const EntryInputContainer = ({
     }
   }, [submissionType, setValidationErrors, entry, selectedFiles, recordings]);
 
-  const setLevelAndClearState = (level: number) => {
+  const setLevelAndClearState = (level: number, confirm = false) => {
+    const shouldRestore =
+      (inputType === 'form' && level === 1 && !confirm) ||
+      (inputType === 'update' && level === 0 && !confirm);
+
+    if (shouldRestore) {
+      const saved = tempState.getSaved();
+      if (saved) {
+        Object.entries(saved.entry).forEach(([key, value]) => {
+          onFieldChange(key, value as FieldValueType);
+        });
+        setActiveFormField(saved.activeFormField);
+        setSelectedHazardType(saved.selectedHazardType);
+        setSelectedHazardIndex(saved.selectedHazardIndex);
+
+        selectedFiles.forEach(file => {
+          onRemoveSelectedFile(file.name);
+        });
+        recordings.forEach(recording => {
+          onRemoveRecording(recording.name);
+        });
+        onFilesSelected(saved.selectedFiles);
+
+        setSketchLines(saved.sketchLines);
+        resetCustomFormData();
+        saved.customFormData.forEach(prop => {
+          onCustomFormDataChange(prop.id, prop.label, String(prop.value));
+        });
+      }
+      setHazardChanges({});
+      tempState.clear();
+    }
+
     setLevel(level);
 
     if (inputType === 'form') {
@@ -164,41 +239,15 @@ export const EntryInputContainer = ({
           resetCustomFormData();
         }
 
-        setAddingCustomForm(false);
-        setAddingDescription(false);
-        setAddingSiteRepDetails(false);
-        setAddingHazard(false);
-        setAddingComments(false);
-        setAddingRiskAssessmentToReview(false);
-        setAddingFormFields(false);
-        setAddingDateAndTime(false);
-        setAddingLocation(false);
-        setAddingAttachments(false);
-        setAddingSketch(false);
+        setActiveField(null);
       }
     } else if (inputType === 'update') {
       if (level === 0) {
-        setAddingDescription(false);
-        setAddingDateAndTime(false);
-        setAddingLocation(false);
-        setAddingAttachments(false);
-        setAddingSketch(false);
+        setActiveField(null);
       }
     }
   };
 
-  const onContentChange = (id: string, json: string, text: string) => {
-    onFieldChange(id, { json, text });
-  };
-
-  const dispatchOnChange = (d: string | undefined, t: string | undefined) => {
-    if (d && t) {
-      const parseDate = Date.parse(`${d}T${t}`);
-      if (!Number.isNaN(parseDate)) {
-        onFieldChange('dateTime', new Date(`${d}T${t}`).toISOString());
-      }
-    }
-  };
 
   const onNestedFieldChange = (id: string, value: FieldValueType) => {
     onFieldChange(id, value, true);
@@ -210,141 +259,87 @@ export const EntryInputContainer = ({
     value: string | undefined,
     selectedRelevantHazards: string[]
   ) => {
+    saveCurrentState();
     const relevantHazardField = getRelevantHazard();
     const options = relevantHazardField.options?.filter(
       (option) => option.value === value || !selectedRelevantHazards.includes(option.value)
     );
 
     setCustomHeading(label);
-    setFormField({
+    setActiveFormField({
       ...relevantHazardField,
       value: value,
       options
     });
-    setAddingHazard(true);
-    setHazardValue(value ?? '');
+    setActiveField('hazard');
+    setSelectedHazardType(value ?? '');
     setSelectedHazardIndex(index);
     setLevel(2);
   };
 
-  const hazardOptionData = (
-    index: number,
-    required: boolean,
-    label: string,
-    selectedRelevantHazards: string[]
-  ): EntityOptionData => {
-    if (selectedRelevantHazards.length > 0) {
-      if (index < selectedRelevantHazards.length) {
-        return {
-          id: `selectHazard-${index}`,
-          onClick: () =>
-            onHazardOptionClick(
-              index,
-              label,
-              selectedRelevantHazards[index],
-              selectedRelevantHazards
-            ),
-          label: label,
-          value: selectedRelevantHazards[index],
-          required,
-          supportedOffline: true
-        };
-      }
+  const onRemoveHazard = (index: number) => {
+    const entry = getEntryWithHazardChanges();
+    const relevantHazardsField = formFields.find(f => f.id === RelevantHazards.id);
+    const selectedHazards = relevantHazardsField ? getFieldValue(relevantHazardsField, entry) as string[] | undefined || [] : [];
 
-      return {
-        id: `selectHazard-${index}`,
-        onClick: () => onHazardOptionClick(index, label, undefined, selectedRelevantHazards),
-        label: label,
-        value: undefined,
-        required,
-        supportedOffline: true
-      };
-    } else {
-      const relevantHazardsField = formFields.find(
-        (formField) => formField.id === RelevantHazards.id
-      );
-
-      if (relevantHazardsField) {
-        const relevantHazardsValue = getFieldValue(relevantHazardsField, entry);
-
-        if (relevantHazardsValue && index < relevantHazardsValue.length - 1) {
-          return {
-            id: `selectHazard-${index}`,
-            onClick: () =>
-              onHazardOptionClick(
-                index,
-                label,
-                relevantHazardsValue[index],
-                selectedRelevantHazards
-              ),
-            label: label,
-            value: relevantHazardsValue[index],
-            required,
-            supportedOffline: true
-          };
-        }
-
-        return {
-          id: `selectHazard-${index}`,
-          onClick: () => onHazardOptionClick(index, label, undefined, selectedRelevantHazards),
-          label: label,
-          value: undefined,
-          required,
-          supportedOffline: true
-        };
-      }
-
-      return {
-        id: `selectHazard-${index}`,
-        onClick: () => onHazardOptionClick(index, label, undefined, selectedRelevantHazards),
-        label: label,
-        value: undefined,
-        required,
-        supportedOffline: true
-      };
-    }
+    const updatedHazards = selectedHazards.filter((_, i) => i !== index);
+    onNestedFieldChange(RelevantHazards.id, updatedHazards);
   };
 
-  const updateHazardOptionData = (
-    option: EntityOptionData,
-    index: number,
-    value: string | undefined,
-    relevantHazards: string[] | undefined,
-    removable: boolean
-  ): EntityOptionData => ({
-    ...option,
-    id: `selectHazard-${index}`,
-    value: value ?? option.value,
-    valueLabel: value ? getHazardLabel(value) : option.valueLabel,
-    onClick: () =>
-      onHazardOptionClick(index, option.label!, value ?? option.value, relevantHazards ?? []),
-    removable
-  });
+  const getHazardOptions = (): EntityOptionData[] => {
+    const entry = getEntryWithHazardChanges();
+    const relevantHazardsField = formFields.find(f => f.id === RelevantHazards.id);
+    const selectedHazards = relevantHazardsField ? getFieldValue(relevantHazardsField, entry) as string[] | undefined || [] : [];
 
-  const reconcileReleventHazards = (
-    relevantHazardsFieldValue: string | string[] | undefined,
-    value: string
-  ) => {
-    let relevantHazards = [value];
+    const options: EntityOptionData[] = [];
 
-    if (relevantHazardsFieldValue) {
-      if (selectedHazardIndex >= 0 && selectedHazardIndex < relevantHazardsFieldValue.length) {
-        relevantHazards = [
-          ...(selectedHazardIndex > 0
-            ? relevantHazardsFieldValue.slice(0, selectedHazardIndex)
-            : relevantHazards),
-          ...(selectedHazardIndex > 0 ? relevantHazards : []),
-          ...(selectedHazardIndex > 0
-            ? relevantHazardsFieldValue.slice(selectedHazardIndex + 1)
-            : [])
-        ];
-      } else {
-        relevantHazards = [...relevantHazardsFieldValue, ...relevantHazards];
-      }
-    }
+    selectedHazards.forEach((hazard, index) => {
+      options.push({
+        id: `selectHazard-${index}`,
+        onClick: () => onHazardOptionClick(index, 'Select hazard', hazard, selectedHazards),
+        label: 'Select hazard',
+        value: hazard,
+        valueLabel: getHazardLabel(hazard),
+        required: index === 0,
+        supportedOffline: true,
+        removable: selectedHazards.length > 1,
+        onRemove: () => onRemoveHazard(index)
+      });
+    });
 
-    return relevantHazards;
+    options.push({
+      id: `selectHazard-${selectedHazards.length}`,
+      onClick: () => onHazardOptionClick(selectedHazards.length, selectedHazards.length === 0 ? 'Select hazard' : 'Add hazard', undefined, selectedHazards),
+      label: selectedHazards.length === 0 ? 'Select hazard' : 'Add hazard',
+      value: undefined,
+      required: selectedHazards.length === 0,
+      supportedOffline: true
+    });
+
+    return options;
   };
+
+  const getRiskReviewOptions = (): EntityOptionData[] => [
+    ...getHazardOptions(),
+    {
+      id: 'addComments',
+      onClick: () => {
+        saveCurrentState();
+        setCustomHeading('Add comments');
+        setActiveFormField(formFields.find((field) => field.id === 'Comments'));
+        setActiveField('comments');
+        setLevel(2);
+      },
+      label: 'Add comments',
+      value:
+        ((entry.type === 'RiskAssessment' || entry.type === 'RiskAssessmentReview') &&
+          formFields
+            .filter((activeFormField) => activeFormField.id === 'Comments')
+            .map((activeFormField) => getFieldValue(activeFormField, entry)?.toString())?.[0]) ||
+        undefined,
+      supportedOffline: true
+    }
+  ];
 
   const onFormTypeChange = (formType: string) => {
     if (formType === 'CustomForm') {
@@ -354,9 +349,6 @@ export const EntryInputContainer = ({
       onFieldChange('type', formType);
       setSubmissionType('entry');
 
-      if (formType === 'RiskAssessment') {
-        setHazardsOptionData([hazardOptionData(0, true, 'Select hazard', [])]);
-      }
     }
 
     setLevel(1);
@@ -369,181 +361,33 @@ export const EntryInputContainer = ({
 
     if (selectedCustomForm) {
       setCustomForm(selectedCustomForm);
-      setAddingCustomForm(true);
+      setActiveField('customForm');
       setLevel(2);
     }
   };
 
-  const onRemoveHazard = (index: number, relevantHazards: string[]) => {
-    const value = index > 0 ? relevantHazards.at(index) : undefined;
-
-    if (value) {
-      const updatedRelevantHazards =
-        index === relevantHazards.length - 1
-          ? [...relevantHazards.slice(0, index), ...relevantHazards.slice(index + 1)]
-          : undefined;
-
-      if (updatedRelevantHazards) {
-        onNestedFieldChange(RelevantHazards.id, updatedRelevantHazards);
-
-        let updatedAdditionalHazardsOptionData: EntityOptionData[] = [];
-
-        if (index === hazardsOptionData.length - 2) {
-          updatedAdditionalHazardsOptionData = [
-            ...hazardsOptionData.slice(0, index).map((data, innerIndex) => {
-              if (innerIndex === index - 1) {
-                return updateHazardOptionData(
-                  data,
-                  innerIndex,
-                  undefined,
-                  updatedRelevantHazards,
-                  innerIndex > 0
-                );
-              }
-              return updateHazardOptionData(
-                data,
-                innerIndex,
-                undefined,
-                updatedRelevantHazards,
-                false
-              );
-            }),
-            hazardOptionData(index, false, 'Add hazard', updatedRelevantHazards)
-          ];
-        }
-
-        setHazardsOptionData(updatedAdditionalHazardsOptionData);
-        setRefreshRemoveHazardsCall(true);
-      }
-    }
-  };
-
-  useEffect(() => {
-    if (inputType === 'form' && formFields) {
-      const relevantHazardsField = formFields.find(
-        (formField) => formField.id === RelevantHazards.id
-      );
-
-      if (relevantHazardsField) {
-        const relevantHazardsFieldValue = getFieldValue(relevantHazardsField, entry);
-
-        if (relevantHazardsFieldValue) {
-          if (hazardsOptionData.some((option) => option.removable)) {
-            const underlyingValue = relevantHazardsFieldValue.valueOf();
-
-            if (Array.isArray(underlyingValue)) {
-              const updateAdditionalHazardsOptionData = hazardsOptionData.map((option, index) => {
-                if (option.removable) {
-                  return {
-                    ...option,
-                    onRemove: () => onRemoveHazard(index, underlyingValue)
-                  };
-                }
-                return option;
-              });
-              setHazardsOptionData(updateAdditionalHazardsOptionData);
-            }
-          }
-        }
-      }
-    }
-
-    return setRefreshRemoveHazardsCall(false);
-  }, [inputType, refreshRemoveHazardsCall]);
-
-  const updateAdditionalOptionData = (value: string, selectedRelevantHazards: string[]) => {
-    let updatedAdditionalHazardsOptionData = hazardsOptionData;
-
-    if (updatedAdditionalHazardsOptionData.length < selectedHazardIndex + 2) {
-      updatedAdditionalHazardsOptionData.push(
-        hazardOptionData(selectedHazardIndex + 1, false, 'Add hazard', selectedRelevantHazards)
-      );
-    }
-
-    updatedAdditionalHazardsOptionData = updatedAdditionalHazardsOptionData.map((data, index) => {
-      const removable = index > 0 && index === hazardsOptionData.length - 2;
-
-      if (index === selectedHazardIndex) {
-        return updateHazardOptionData(data, index, value, selectedRelevantHazards, removable);
-      }
-
-      return updateHazardOptionData(data, index, undefined, selectedRelevantHazards, removable);
-    });
-
-    setHazardsOptionData(updatedAdditionalHazardsOptionData);
-  };
 
   const handleRelevantHazardsChange = (id: string, value: FieldValueType) => {
-    if (id === RelevantHazard.id) {
-      const relevantHazardsField = formFields.find(
-        (formField) => formField.id === RelevantHazards.id
-      );
+    if (id === getRelevantHazard().id && typeof value === 'string') {
+      const entry = getEntryWithHazardChanges();
+      const relevantHazardsField = formFields.find(f => f.id === RelevantHazards.id);
+      const currentHazards = relevantHazardsField ? getFieldValue(relevantHazardsField, entry) as string[] | undefined || [] : [];
 
-      if (relevantHazardsField) {
-        const relevantHazardsFieldValue = getFieldValue(relevantHazardsField, entry);
+      const updatedHazards = [...currentHazards];
+      if (selectedHazardIndex < updatedHazards.length) {
+        updatedHazards[selectedHazardIndex] = value;
+      } else {
+        updatedHazards.push(value);
+      }
 
-        if (value) {
-          const underlyingValue = value.valueOf();
+      setSelectedHazardType(value);
+      onHazardFieldChange(RelevantHazards.id, updatedHazards);
 
-          if (typeof underlyingValue === 'string') {
-            const relevantHazards = reconcileReleventHazards(
-              relevantHazardsFieldValue,
-              underlyingValue
-            );
-
-            setHazardValue(underlyingValue);
-            onNestedFieldChange(RelevantHazards.id, relevantHazards);
-
-            updateAdditionalOptionData(underlyingValue, relevantHazards);
-            setRefreshRemoveHazardsCall(true);
-
-            if (formField) {
-              setFormField({ ...formField, value: underlyingValue });
-            } else {
-              setFormField({ ...getRelevantHazard(), value: underlyingValue });
-            }
-          }
-        }
+      if (activeFormField) {
+        setActiveFormField({ ...activeFormField, value });
       }
     }
   };
-
-  useEffect(() => {
-    if (inputType === 'form' && entry.type === 'RiskAssessmentReview') {
-      const relevantHazardsField = formFields.find(
-        (formField) => formField.id === RelevantHazards.id
-      );
-
-      if (relevantHazardsField) {
-        const relevantHazardsFieldValue = getFieldValue(relevantHazardsField, entry);
-
-        if (relevantHazardsFieldValue) {
-          if (Array.isArray(relevantHazardsFieldValue)) {
-            const relevantHazardOptions: EntityOptionData[] = relevantHazardsFieldValue
-              .map((_value, index) => {
-                if (index === 0) {
-                  return hazardOptionData(0, true, 'Select hazard', relevantHazardsFieldValue);
-                }
-
-                return hazardOptionData(index, false, 'Add hazard', relevantHazardsFieldValue);
-              })
-              .concat(
-                hazardOptionData(
-                  relevantHazardsFieldValue.length,
-                  false,
-                  'Add hazard',
-                  relevantHazardsFieldValue
-                )
-              );
-
-            setHazardsOptionData(relevantHazardOptions);
-          }
-        }
-      }
-    }
-
-    return setRefreshHazardOptions(false);
-  }, [inputType, refreshHazardOptions]);
 
   const getFormattedValueForField = (field: Field, value: FieldValueType) => {
     if (field.id === 'CommunicationMethod') {
@@ -561,10 +405,10 @@ export const EntryInputContainer = ({
     ? []
     : formFields;
   const dependentFieldIds = filteredFormFieldsForView.map(
-    (formField) => formField.dependentFieldId
+    (activeFormField) => activeFormField.dependentFieldId
   );
   const parentFormFields = filteredFormFieldsForView.filter(
-    (formField) => !dependentFieldIds.includes(formField.id)
+    (activeFormField) => !dependentFieldIds.includes(activeFormField.id)
   );
 
   const descriptionOptionData = (
@@ -574,11 +418,12 @@ export const EntryInputContainer = ({
     {
       id: 'description',
       onClick: () => {
+        saveCurrentState();
         setCustomHeading(descriptionHeading);
-        setAddingDescription(true);
+        setActiveField('description');
         setLevel(onClickLevel);
       },
-      value: entry.content?.text ? entry.content.text : undefined,
+      value: entry.content?.text || undefined,
       supportedOffline: true
     }
   ];
@@ -587,13 +432,14 @@ export const EntryInputContainer = ({
     {
       id: 'sitRepDetails',
       onClick: () => {
+        saveCurrentState();
         setCustomHeading('Details');
-        setAddingSiteRepDetails(true);
+        setActiveField('siteRepDetails');
         setLevel(2);
       },
       label: formFields
-        .filter((formField) => formField.id !== 'ExactLocation')
-        .every((formField) => getFieldValue(formField, entry))
+        .filter((activeFormField) => activeFormField.id !== 'ExactLocation')
+        .every((activeFormField) => getFieldValue(activeFormField, entry))
         ? 'View details'
         : undefined,
       value: 'Details',
@@ -602,42 +448,23 @@ export const EntryInputContainer = ({
     }
   ];
 
-  const riskReviewOptionData: EntityOptionData[] = [
-    ...hazardsOptionData,
-    {
-      id: 'addComments',
-      onClick: () => {
-        setCustomHeading('Add comments');
-        setFormField(formFields.find((formField) => formField.id === 'Comments'));
-        setAddingComments(true);
-        setLevel(2);
-      },
-      label: 'Add comments',
-      value:
-        ((entry.type === 'RiskAssessment' || entry.type === 'RiskAssessmentReview') &&
-          formFields
-            .filter((formField) => formField.id === 'Comments')
-            .map((formField) => getFieldValue(formField, entry)?.toString())?.[0]) ||
-        undefined,
-      supportedOffline: true
-    }
-  ];
 
   const riskAssessmentReviewOptionData = (): EntityOptionData[] => {
     const value =
       (entry.type === 'RiskAssessmentReview' &&
         formFields
-          .filter((formField) => formField.id === 'Review')
-          .map((formField) => getFieldValue(formField, entry)?.toString())?.[0]) ||
+          .filter((activeFormField) => activeFormField.id === 'Review')
+          .map((activeFormField) => getFieldValue(activeFormField, entry)?.toString())?.[0]) ||
       undefined;
     const linkedEntry = entries.find((e) => e.id === value);
     return [
       {
         id: 'riskAssessmentReview',
         onClick: () => {
+          saveCurrentState();
           setCustomHeading('Select risk assessment to review');
-          setFormField(formFields.find((formField) => formField.id === 'Review'));
-          setAddingRiskAssessmentToReview(true);
+          setActiveFormField(formFields.find((field) => field.id === 'Review'));
+          setActiveField('riskAssessmentToReview');
           setLevel(2);
         },
         label: 'Select risk assessment to review',
@@ -647,7 +474,7 @@ export const EntryInputContainer = ({
           undefined,
         supportedOffline: true
       },
-      ...(value ? riskReviewOptionData : [])
+      ...(value ? getRiskReviewOptions() : [])
     ];
   };
 
@@ -663,8 +490,9 @@ export const EntryInputContainer = ({
     {
       id: 'dateAndTime',
       onClick: () => {
+        saveCurrentState();
         setCustomHeading('Add date and time');
-        setAddingDateAndTime(true);
+        setActiveField('dateAndTime');
         setLevel(onClickLevel);
       },
       value: entry.dateTime
@@ -675,8 +503,9 @@ export const EntryInputContainer = ({
     {
       id: 'location',
       onClick: () => {
+        saveCurrentState();
         setCustomHeading(addLocationHeading);
-        setAddingLocation(true);
+        setActiveField('location');
         setLevel(onClickLevel);
       },
       label: addLocationHeading,
@@ -686,8 +515,9 @@ export const EntryInputContainer = ({
     {
       id: 'attachments',
       onClick: () => {
+        saveCurrentState();
         setCustomHeading('Add attachment(s)');
-        setAddingAttachments(true);
+        setActiveField('attachments');
         setLevel(onClickLevel);
       },
       value: selectedFiles.length > 0 ? `${selectedFiles.length} attachments` : undefined,
@@ -696,8 +526,9 @@ export const EntryInputContainer = ({
     {
       id: 'sketch',
       onClick: () => {
+        saveCurrentState();
         setCustomHeading('Add sketch');
-        setAddingSketch(true);
+        setActiveField('sketch');
         setLevel(onClickLevel);
       },
       value: sketchLines.length > 0 ? 'View sketch' : undefined,
@@ -725,7 +556,7 @@ export const EntryInputContainer = ({
       ...(inputType === 'form' && entry.type === 'RiskAssessmentReview'
         ? riskAssessmentReviewOptionData()
         : []),
-      ...(inputType === 'form' && entry.type === 'RiskAssessment' ? riskReviewOptionData : []),
+      ...(inputType === 'form' && entry.type === 'RiskAssessment' ? getRiskReviewOptions() : []),
       ...(inputType === 'form'
         ? parentFormFields.map(
           (field) =>
@@ -733,9 +564,10 @@ export const EntryInputContainer = ({
                 id: `field-${field.id}`,
                 dependentId: field.dependentFieldId,
                 onClick: () => {
+                  saveCurrentState();
                   setCustomHeading(`Add ${field.title ?? 'field'}`);
-                  setAddingFormFields(true);
-                  setFormField(field);
+                  setActiveField('formFields');
+                  setActiveFormField(field);
                   setLevel(2);
                 },
                 value: getFormattedValueForField(
@@ -756,44 +588,158 @@ export const EntryInputContainer = ({
     ];
   };
 
-  const baseInputControls = (): ReactNode[] => [
-    addingDateAndTime && (
-      <DateAndTimePicker
-        dateLabel="Date"
-        timeLabel="Time"
-        dateLowerBound={incident.startedAt}
-        disableFuture
-        value={entry.dateTime}
-        onChange={dispatchOnChange}
-      />
-    ),
-    addingLocation && (
-      <Location.Content
-        required={false}
-        location={entry.location}
-        onLocationChange={onLocationChange}
-        validationErrors={validationErrors}
-      />
-    ),
-    addingAttachments && (
-      <Files.Content
-        active={addingAttachments}
-        selectedFiles={selectedFiles}
-        recordings={recordings}
-        onFilesSelected={onFilesSelected}
-        removeSelectedFile={onRemoveSelectedFile}
-        removeRecording={onRemoveRecording}
-      />
-    ),
-    addingSketch && (
-      <Sketch.Content
-        active={addingSketch}
-        canvasRef={canvasRef}
-        lines={sketchLines}
-        onChangeLines={setSketchLines}
-      />
-    )
-  ];
+  const handleDateTimeChange = useCallback((d: string | undefined, t: string | undefined) => {
+    if (d && t) {
+      const parseDate = Date.parse(`${d}T${t}`);
+      if (!Number.isNaN(parseDate)) {
+        onFieldChange('dateTime', new Date(`${d}T${t}`).toISOString());
+      }
+    }
+  }, [onFieldChange]);
+
+  const renderFieldInput = () => {
+    if (!activeField) return null;
+
+    const hasHazardChanges = Object.keys(hazardChanges).length > 0;
+
+    const hasDataChanges = tempState.hasChangesInProps({
+      entry,
+      selectedFiles,
+      sketchLines,
+      customFormData
+    });
+
+    const isDirty = hasHazardChanges || hasDataChanges;
+
+    const fieldInput = (() => {
+      switch (activeField) {
+        case 'description':
+          return (
+            <EntryContent
+              id="content"
+              editable
+              json={typeof entry.content === 'object' ? entry.content.json : undefined}
+              recordingActive={false}
+              onRecording={undefined}
+              onChange={(id: string, json: string, text: string) => {
+                onFieldChange(id, { json, text });
+              }}
+              error={false}
+              mentionables={mentionables}
+            />
+          );
+
+        case 'dateAndTime':
+          return (
+            <DateAndTimePicker
+              dateLabel="Date"
+              timeLabel="Time"
+              dateLowerBound={incident.startedAt}
+              disableFuture
+              value={entry.dateTime}
+              onChange={handleDateTimeChange}
+            />
+          );
+
+        case 'location':
+          return (
+            <Location.Content
+              location={entry.location}
+              validationErrors={validationErrors}
+              onLocationChange={onLocationChange}
+            />
+          );
+
+        case 'attachments':
+          return (
+            <Files.Content
+              active={true}
+              selectedFiles={selectedFiles}
+              recordings={recordings}
+              onFilesSelected={onFilesSelected}
+              removeSelectedFile={onRemoveSelectedFile}
+              removeRecording={onRemoveRecording}
+            />
+          );
+
+        case 'sketch':
+          return (
+            <Sketch.Content
+              active={true}
+              canvasRef={canvasRef}
+              lines={sketchLines}
+              onChangeLines={setSketchLines}
+            />
+          );
+
+        case 'siteRepDetails':
+          return forms ? (
+            <CustomFormContainer
+              entry={entry}
+              selectedForm={forms.find((form) => form.id === 'siteRepMethane')!}
+              fields={formFields}
+              onFieldChange={onNestedFieldChange}
+            />
+          ) : null;
+
+        case 'formFields':
+        case 'comments':
+        case 'riskAssessmentToReview':
+        case 'hazard':
+          return formFields && activeFormField ? (
+            <Box display="flex" flexDirection="column" gap={2}>
+              <GenericFormField
+                field={activeFormField}
+                fields={formFields}
+                entry={getEntryWithHazardChanges()}
+                entries={entries}
+                onChange={(id, value) => {
+                  if (activeField === 'hazard') {
+                    handleRelevantHazardsChange(id, value);
+                  } else {
+                    onNestedFieldChange(id, value);
+                  }
+                }}
+                errors={validationErrors}
+              />
+              {activeField === 'hazard' && selectedHazardType && forms && (
+                <CustomFormContainer
+                  entry={getEntryWithHazardChanges()}
+                  selectedForm={forms.find((form) => form.id === `haz_${selectedHazardType.toLowerCase()}`)!}
+                  fields={formFields}
+                  onFieldChange={onHazardFieldChange}
+                />
+              )}
+            </Box>
+          ) : null;
+
+        default:
+          return null;
+      }
+    })();
+
+    return (
+      <Box>
+        {fieldInput}
+        <Box display="flex" justifyContent="flex-end" marginTop={2}>
+          <Button
+            onClick={() => {
+              applyHazardChangesToParent();
+              setLevelAndClearState(
+                inputType === 'form' ? 1 : 0,
+                true
+              );
+            }}
+            variant="contained"
+            disabled={!isDirty}
+          >
+            Confirm
+          </Button>
+        </Box>
+      </Box>
+    );
+  };
+
 
   const formInputContainerData = (): EntityInputContainerData[] => [
     {
@@ -845,7 +791,7 @@ export const EntryInputContainer = ({
       ),
       showButtons: true
     },
-    (addingCustomForm &&
+    (activeField === 'customForm' &&
       customForm && {
       heading: `New custom form - ${customForm.title}`,
       inputControls: (
@@ -864,60 +810,7 @@ export const EntryInputContainer = ({
       heading: customHeading,
       inputControls: (
         <Box padding={2}>
-          {addingDescription && (
-            <EntryContent
-              id="content"
-              editable
-              json={typeof entry.content === 'object' ? entry.content.json : undefined}
-              recordingActive={false}
-              onRecording={undefined}
-              onChange={onContentChange}
-              error={false}
-              mentionables={mentionables}
-            />
-          )}
-          {addingSiteRepDetails && forms && (
-            <CustomFormContainer
-              entry={entry}
-              selectedForm={forms.find((form) => form.id === 'siteRepMethane')!}
-              fields={formFields}
-              onFieldChange={onNestedFieldChange}
-            />
-          )}
-          {(addingFormFields || addingComments || addingRiskAssessmentToReview || addingHazard) &&
-            formFields &&
-            formField && (
-            <Box display="flex" flexDirection="column" gap={2}>
-              <GenericFormField
-                field={formField}
-                fields={formFields}
-                entry={entry}
-                entries={entries}
-                onChange={(id, value) => {
-                  if (addingHazard) {
-                    handleRelevantHazardsChange(id, value);
-                  } else {
-                    onNestedFieldChange(id, value);
-                    if (addingRiskAssessmentToReview) {
-                      setRefreshHazardOptions(true);
-                    }
-                  }
-                }}
-                errors={validationErrors}
-              />
-              {addingHazard && hazardValue && forms && (
-                <CustomFormContainer
-                  entry={entry}
-                  selectedForm={
-                      forms.find((form) => form.id === `haz_${hazardValue.toLowerCase()}`)!
-                  }
-                  fields={formFields}
-                  onFieldChange={onNestedFieldChange}
-                />
-              )}
-            </Box>
-          )}
-          {baseInputControls()}
+          {renderFieldInput()}
         </Box>
       ),
       containerBackgroundColor: 'background.default'
@@ -940,19 +833,7 @@ export const EntryInputContainer = ({
       heading: customHeading,
       inputControls: (
         <Box padding={2}>
-          {addingDescription && (
-            <EntryContent
-              id="content"
-              editable
-              json={typeof entry.content === 'object' ? entry.content.json : undefined}
-              recordingActive={false}
-              onRecording={undefined}
-              onChange={onContentChange}
-              error={false}
-              mentionables={mentionables}
-            />
-          )}
-          {baseInputControls()}
+          {renderFieldInput()}
         </Box>
       ),
       containerBackgroundColor: 'background.default'

--- a/frontend/src/hooks/useTemporaryState.ts
+++ b/frontend/src/hooks/useTemporaryState.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+// and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
+
+import { useRef } from 'react';
+
+export function useTemporaryState<T extends Record<string, unknown>>() {
+  const savedState = useRef<T | null>(null);
+
+  const save = (currentState: T) => {
+    savedState.current = structuredClone(currentState);
+  };
+
+  const getSaved = (): T | null => {
+    return savedState.current;
+  };
+
+  const clear = () => {
+    savedState.current = null;
+  };
+
+  const hasChanges = (currentState: T): boolean => {
+    if (!savedState.current) return false;
+    return JSON.stringify(savedState.current) !== JSON.stringify(currentState);
+  };
+
+  const hasChangesInProps = <K extends Partial<T>>(propsToCheck: K): boolean => {
+    if (!savedState.current) return false;
+
+    const savedProps = Object.fromEntries(
+      Object.keys(propsToCheck).map(key => [key, savedState.current![key as keyof T]])
+    );
+
+    return JSON.stringify(savedProps) !== JSON.stringify(propsToCheck);
+  };
+
+  return { save, getSaved, clear, hasChanges, hasChangesInProps };
+}

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -8,6 +8,8 @@ import { TextEncoder } from 'util';
 
 global.TextEncoder = TextEncoder;
 
+global.structuredClone = global.structuredClone || ((obj) => JSON.parse(JSON.stringify(obj)));
+
 Object.defineProperty(global, 'crypto', {
   value: {
     subtle: crypto.webcrypto.subtle


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

## Motivation and Context
https://ndtp.atlassian.net/browse/DPAV-1679

## Description
Add useTemporaryState hook to restore the entity/form back to its
original state when the back button is pressed.

Refactored EntryInputContainer to replace refresh flags and stored options
to be computed, though the confirm/cancel pattern is more complex here due
to nested hazard subforms and dynamic field dependencies.

## How Has This Been Tested?
Locally

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.