### PR TITLE
bugfix(DPAV-1441): capture sketch before canvas unmount

### DIFF
--- a/frontend/src/pages/CreateEntry.tsx
+++ b/frontend/src/pages/CreateEntry.tsx
@@ -6,14 +6,13 @@ import { useFormTemplates } from '../hooks/Forms/useFormTemplates';
 import { useCreateFormInstance } from '../hooks/Forms/useFormInstances';
 import { useIsOnline } from '../hooks/useIsOnline';
 import { LogEntry } from 'common/LogEntry';
-import { MouseEvent, useEffect, useMemo, useRef, useState } from 'react';
+import { MouseEvent, useEffect, useMemo, useState } from 'react';
 import { createSequenceNumber } from '../utils/Form/sequence';
 import { Form, FormDataProperty } from '../components/CustomForms/FormTemplates/types';
 import { Field } from 'common/Field';
-import { FieldValueType, SketchLine } from '../utils/types';
-import { Stage } from 'konva/lib/Stage';
+import { FieldValueType } from '../utils/types';
 import { Mentionable } from 'common/Mentionable';
-import { Document, Format, Form as FormUtils } from '../utils';
+import { Format, Form as FormUtils } from '../utils';
 import { LogEntryTypes } from 'common/LogEntryTypes';
 import { LogEntryType } from 'common/LogEntryType';
 import { Attachment } from 'common/Attachment';
@@ -67,8 +66,7 @@ export const CreateEntry = ({ inputType }: Props) => {
   const [formFields, setFormFields] = useState<Field[]>([]);
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const [recordings, setRecordings] = useState<File[]>([]);
-  const [sketchLines, setSketchLines] = useState<SketchLine[]>([]);
-  const canvasRef = useRef<Stage>(null);
+  const [sketchFile, setSketchFile] = useState<File | null>(null);
 
   const otherAttachments: Array<Mentionable> = useMemo(() => {
     if (!incidentAttachments) {
@@ -162,20 +160,18 @@ export const CreateEntry = ({ inputType }: Props) => {
       type: 'Recording',
       name: recording.name
     }));
+
     const sketchAttachments: Attachment[] = [];
-    const sketches: File[] = [];
-    if (sketchLines.length > 0) {
-      const dataURL = canvasRef.current?.toDataURL();
-      if (dataURL) {
-        const file = Document.dataURLtoFile(dataURL, `Sketch ${Format.timestamp()}.png`);
-        sketchAttachments.push({ type: 'Sketch', name: file.name });
-        sketches.push(file);
-      }
+    const allFiles: File[] = [...selectedFiles, ...recordings];
+    if (sketchFile) {
+      sketchAttachments.push({ type: 'Sketch', name: sketchFile.name });
+      allFiles.push(sketchFile);
     }
+
     const attachments = [...fileAttachments, ...recordingAttachments, ...sketchAttachments];
     entry.attachments = attachments.length > 0 ? attachments : undefined;
 
-    onCreateEntry({ ...entry } as LogEntry, [...selectedFiles, ...recordings, ...sketches]);
+    onCreateEntry({ ...entry } as LogEntry, allFiles);
   };
 
   const onCustomFormSubmit = () => {
@@ -244,16 +240,14 @@ export const CreateEntry = ({ inputType }: Props) => {
         onFilesSelected={onFilesSelected}
         onRemoveSelectedFile={onRemoveSelectedFile}
         onRemoveRecording={onRemoveRecording}
-        setSketchLines={setSketchLines}
         onLocationChange={onLocationChange}
+        setSketchFile={setSketchFile}
         onMainBackClick={handleCancel}
         onSubmit={onSubmit}
         onCancel={handleCancel}
         mentionables={mentionables}
         selectedFiles={selectedFiles}
         recordings={recordings}
-        canvasRef={canvasRef}
-        sketchLines={sketchLines}
       />
     </PageWrapper>
   );


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
Sketch saving was not working
https://ndtp.atlassian.net/browse/DPAV-1441?focusedCommentId=13157

## Description
Moves canvas capturing into the input container so it can be handled before its unmounted.

## How Has This Been Tested?
Locally

## Screenshots (if appropriate):
<img width="379" height="224" alt="Screenshot 2025-09-09 at 16 03 09" src="https://github.com/user-attachments/assets/193021b0-eea5-4d5c-8a0e-dfc647aefd39" />


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.