### PR TITLE
bugfix(DPAV-1584): Hide Incident type/date fields when editing

### DIFF
--- a/frontend/src/components/Incident/IncidentInputContainer.tsx
+++ b/frontend/src/components/Incident/IncidentInputContainer.tsx
@@ -286,16 +286,16 @@ export const IncidentInputContainer = ({
 
   const isDisabled = (key: FieldType) => key === 'time' && isEditing;
 
-  const entityOptionData: EntityOptionData[] = (Object.keys(fieldConfigs) as FieldType[]).map(
-    (field) => ({
+  const entityOptionData: EntityOptionData[] = (Object.keys(fieldConfigs) as FieldType[])
+    .filter((field) => !isEditing || (field !== 'type' && field !== 'time'))
+    .map((field) => ({
       id: field,
       onClick: () => activateField(field),
       value: displayValue(getFieldValue(field) as string | undefined),
       required: fieldConfigs[field].required,
       supportedOffline: fieldConfigs[field].supportedOffline,
       disabled: isDisabled(field)
-    })
-  );
+    }));
 
   function finalizeIncident(i: Partial<Incident>): Incident {
     return i as Incident;

--- a/frontend/src/components/__tests__/Incident/IncidentInputContainer.test.tsx
+++ b/frontend/src/components/__tests__/Incident/IncidentInputContainer.test.tsx
@@ -225,7 +225,7 @@ describe('IncidentInputContainer', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('edit mode: disables type, date and time pickers', async () => {
+  test('edit mode: hides type and time fields', async () => {
     const initialIncident: Incident = {
       id: 'inc-1',
       type: 'TerrorismNI',
@@ -250,9 +250,19 @@ describe('IncidentInputContainer', () => {
       />
     );
 
-    await userEvent.click(screen.getByText('open-type'));
-    const typeCombobox = within(screen.getByTestId('incident-type-field')).getByRole('combobox');
-    expect(typeCombobox).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.queryByText('open-type')).not.toBeInTheDocument();
+    expect(screen.queryByText('open-time')).not.toBeInTheDocument();
+
+    // Other fields should still be visible
+    expect(screen.getByText('open-name')).toBeInTheDocument();
+    expect(screen.getByText('open-referrer')).toBeInTheDocument();
+  });
+
+  test('create mode: shows type and time fields', async () => {
+    render(<IncidentInputContainer isEditing={false} onSubmit={jest.fn()} onCancel={() => {}} />);
+
+    expect(screen.getByText('open-type')).toBeInTheDocument();
+    expect(screen.getByText('open-time')).toBeInTheDocument();
   });
 
   test('edit mode: submits SetIncidentInformation log entry (dirty only) via utils', async () => {


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
Edit incident also works but ‘date and time’ and ‘incident type’ still show up when they can’t actually be edited. ‘Date and time’ and ‘incident type’ should not appear when editing a form, as they can’t be edited.

https://ndtp.atlassian.net/browse/DPAV-1584?focusedCommentId=13142

## Description
Filter inputs when in edit mode

## How Has This Been Tested?
Locally, unit test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.