### PR TITLE
bugfix(dpav-1441): date time is now also prefilled when resetting a log entry

### DIFF
--- a/frontend/src/pages/CreateEntry.tsx
+++ b/frontend/src/pages/CreateEntry.tsx
@@ -205,6 +205,7 @@ export const CreateEntry = ({ inputType }: Props) => {
     setEntry({
       incidentId,
       sequence: createSequenceNumber(),
+      dateTime: new Date().toISOString(),
       content: {}
     });
   const resetCustomForm = () => setCustomForm(null);


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The date time field for a log entry was not being pre filled when the user clicked the back button and selected a new form.

## Description
<!--- Describe your changes in detail -->
- Pre filled the date time field for a log entry to now when the user clicked the back button and selected a new form.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested locally and is working as expected.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.