### PR TITLE
feat(DPAV-1714): Handle optimistic task attachment links

### DIFF
--- a/frontend/src/hooks/useTaskUpdates.tsx
+++ b/frontend/src/hooks/useTaskUpdates.tsx
@@ -39,15 +39,13 @@ const mergeTasks = (cachedTasks: Task[] | undefined, serverTasks: Task[]): Task[
   return [...matchedTasks, ...unmatchedTasks];
 };
 
-export function useTasksUpdates(incidentId?: string) {
+export function useTasksUpdates() {
   const queryClient = useQueryClient();
   const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const syncTasks = useCallback(async () => {
-    if (!incidentId) return;
-    
     try {
-      const tasks: Task[] = await get<Task[]>('tasks');
+      const tasks: Task[] = await get<Task[]>('/tasks');
       const cachedTasks: Task[] | undefined = queryClient.getQueryData<Task[]>(['tasks']);
 
       const mergedTasks = mergeTasks(cachedTasks, tasks);
@@ -56,13 +54,11 @@ export function useTasksUpdates(incidentId?: string) {
     } catch (error) {
       console.error(`Error occurred: ${error}. Unable to poll for task updates!`);
     }
-  }, [incidentId, queryClient]);
+  }, [queryClient]);
 
   const startPolling = useCallback(() => {
-    if (!incidentId) return;
-    
     pollingIntervalRef.current = setInterval(syncTasks, POLLING_INTERVAL_MS);
-  }, [syncTasks, incidentId]);
+  }, [syncTasks]);
 
   const clearPolling = useCallback(() => {
     if (pollingIntervalRef.current) {


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
Indicate that the attachments aren't ready yet the same as it does for log entries
https://ndtp.atlassian.net/browse/DPAV-1714

## Description
Pass through isOffline to AttachmentLink and reinstate the polling.
Looks like polling was broken when the all tasks variant was removed,
so this is now fixed on the tasks page as well to poll for updates.


## How Has This Been Tested?
Locally

## Screenshots (if appropriate):
<img width="492" height="959" alt="Screenshot 2025-09-15 at 13 36 06" src="https://github.com/user-attachments/assets/b039357c-23c2-41a5-b7f0-10e05cfb2bab" />

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.