### PR TITLE
feat(NON-REQ): don't keep incident picker & task create in history

### DIFF
--- a/frontend/src/pages/CreateTask.tsx
+++ b/frontend/src/pages/CreateTask.tsx
@@ -37,7 +37,7 @@ export default function CreateTaskPage() {
       { task, files },
       {
         onSuccess: (data) => {
-          navigate(`/tasks/${data.id}`);
+          navigate(`/tasks/${data.id}`, { replace: true });
         },
         onError: (error) => {
           console.error('Task creation failed:', error);

--- a/frontend/src/pages/IncidentPickerPage.tsx
+++ b/frontend/src/pages/IncidentPickerPage.tsx
@@ -31,7 +31,7 @@ export default function IncidentPickerPage() {
       {next?.startsWith('/') && next.includes(':incidentId') ? (
         <IncidentPicker
           incidents={incidents ?? []}
-          onSelect={(incident) => navigate(next.replace(':incidentId', incident.id))}
+          onSelect={(incident) => navigate(next.replace(':incidentId', incident.id), { replace: true })}
         />
       ) : (
         <div style={{ padding: '16px' }}>Invalid or missing next route.</div>


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
> Although it is correct, going back to a blank task form is a little odd for the flow

## Description
    Added replace: true to incident picker & create task navigates so
    the user will be returned to a more natural location if they hit the
    back button, e.g back to /tasks rather than the create task form.


## How Has This Been Tested?
Locally

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.