### PR TITLE
bugfix(DPAV-1698): Set dateTime on optimistic log entry

### DIFF
--- a/frontend/src/hooks/useLogEntriesUpdates.tsx
+++ b/frontend/src/hooks/useLogEntriesUpdates.tsx
@@ -81,6 +81,7 @@ export const addOptimisticLogEntry = async (
   const offlineCount = previousEntries?.filter((entry: LogEntry) => entry.offline).length ?? 0;
   const optimisticEntry: LogEntry = {
     ...logEntry,
+    dateTime: new Date().toISOString(),
     sequence: `${offlineCount + 1}`,
     offline: true
   };


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
So ordering of optimistic update log entry is correct

## Description
Set dateTime to now

## How Has This Been Tested?
Locally

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.