### PR TITLE
bugfix(DPAV-1154): Fix offline support for custom forms

### DIFF
--- a/frontend/src/components/AddEntry/EntryInputContainer.tsx
+++ b/frontend/src/components/AddEntry/EntryInputContainer.tsx
@@ -61,6 +61,7 @@ type Props = {
   onMainBackClick: () => void;
   onSubmit: (submissionType: 'customForm' | 'entry' | null) => void;
   onCancel: () => void;
+  disableSubmit: boolean;
 };
 
 type FieldType =
@@ -103,7 +104,8 @@ export const EntryInputContainer = ({
   setSketchFile,
   onMainBackClick,
   onSubmit,
-  onCancel
+  onCancel,
+  disableSubmit,
 }: Props) => {
   const [level, setLevel] = useState<number>(0);
   const [submissionType, setSubmissionType] = useState<'customForm' | 'entry' | null>(
@@ -918,7 +920,7 @@ export const EntryInputContainer = ({
       onCancel={onCancel}
       level={level}
       setLevel={setLevelAndClearState}
-      disableSubmit={validationErrors.length > 0}
+      disableSubmit={validationErrors.length > 0 || disableSubmit}
     />
   );
 };

--- a/frontend/src/hooks/Forms/useFormInstances.ts
+++ b/frontend/src/hooks/Forms/useFormInstances.ts
@@ -5,7 +5,6 @@
 import { QueryClient, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { v4 as uuidV4 } from 'uuid';
 
-import { LogEntry } from 'common/LogEntry';
 import { FetchError, get, post } from '../../api';
 import { FormInstance } from '../../components/CustomForms/FormTemplates/types';
 import { CreateFormInstanceContext, CreateFormInstancePayload } from './types';
@@ -14,6 +13,7 @@ import { useCreateLogEntry } from '../useLogEntries';
 import { OfflineFormInstance } from '../../offline/types/OfflineForm';
 import { useIsOnline } from '../useIsOnline';
 import { addForm } from '../../offline/db/dbOperations';
+import { addOptimisticLogEntry } from '../useLogEntriesUpdates';
 
 export async function poll(
   incidentId: string | undefined,
@@ -34,7 +34,7 @@ export async function poll(
 
 export const useCreateFormInstance = (incidentId: string, onSuccess: () => void) => {
   const queryClient = useQueryClient();
-  const { createLogEntry } = useCreateLogEntry(incidentId, onSuccess);
+  const { createLogEntry } = useCreateLogEntry(incidentId);
   const isOnline = useIsOnline();
 
   return useMutation<{ id: string }, Error, CreateFormInstancePayload, CreateFormInstanceContext>({
@@ -43,10 +43,9 @@ export const useCreateFormInstance = (incidentId: string, onSuccess: () => void)
 
       const id = uuidV4();
       const createdAt = new Date().toISOString();
+      const logEntry = createLogEntryFromSubmittedForm(uuidV4(), title, id, incidentId, createdAt)
 
       if (!isOnline) {
-        const logEntry = createLogEntryFromSubmittedForm(title, id, incidentId, createdAt);
-
         const offlineForm: OfflineFormInstance = {
           id,
           title,
@@ -55,14 +54,25 @@ export const useCreateFormInstance = (incidentId: string, onSuccess: () => void)
           incidentId,
           createdAt,
           authorName: 'Offline',
-          pendingLogEntry: { ...logEntry, id: uuidV4() }
+          pendingLogEntry: logEntry
         };
 
         await addForm(offlineForm);
+
+        // since we're not using the mutation for log entries
+        // we need to add the optimistic log entry manually
+        // this can go away once log entries support offline operations
+        // rather than two ways of doing it
+        addOptimisticLogEntry(queryClient, incidentId, logEntry);
+
         return { id };
       }
 
-      return post(`/incident/${incidentId}/form`, { formTemplateId, formData, createdAt, id });
+      const response = await post<{ id: string }>(`/incident/${incidentId}/form`, { formTemplateId, formData, createdAt, id });
+
+      createLogEntry({ logEntry });
+
+      return response;
     },
 
     onMutate: async ({ formTemplateId, formData, title }) => {
@@ -89,23 +99,14 @@ export const useCreateFormInstance = (incidentId: string, onSuccess: () => void)
       return { previousFormInstances };
     },
 
+    onSuccess: async () => {
+      onSuccess?.();
+    },
+
     onError: (_err, _vars, context) => {
       if (context?.previousFormInstances) {
         queryClient.setQueryData([`incident/${incidentId}/form`], context.previousFormInstances);
       }
-    },
-
-    onSuccess: async (response, variables) => {
-      const { title: formTitle } = variables;
-      const formId = response.id;
-
-      if (!incidentId || !formTitle || !formId) return;
-
-      const logEntry = {
-        ...createLogEntryFromSubmittedForm(uuidV4(), formTitle, formId, incidentId)
-      } as Omit<LogEntry, 'id' | 'author'>;
-
-      createLogEntry({ logEntry });
     },
 
     networkMode: 'always'
@@ -115,7 +116,7 @@ export const useCreateFormInstance = (incidentId: string, onSuccess: () => void)
 export const useFormInstances = (incidentId?: string) => {
   const { data, isLoading, isError, error } = useQuery<FormInstance[], FetchError>({
     queryKey: [`incident/${incidentId}/form`],
-    queryFn: () => get(`/incident/${incidentId}/form`)
+    queryFn: () => get(`/incident/${incidentId}/form`),
   });
 
   return { forms: data, isLoading, isError, error };

--- a/frontend/src/hooks/Forms/utils.ts
+++ b/frontend/src/hooks/Forms/utils.ts
@@ -11,9 +11,8 @@ export function createLogEntryFromSubmittedForm(
   formId: string,
   incidentId: string,
   dateTime?: string,
-  entry?: Partial<LogEntry>
-): Partial<LogEntry> {
-  const logEntry: Partial<LogEntry> = entry ?? {
+): LogEntry {
+  return {
     id,
     type: 'FormSubmitted',
     incidentId,
@@ -26,6 +25,4 @@ export function createLogEntryFromSubmittedForm(
       submittedFormTitle: formTitle
     }
   };
-
-  return logEntry;
 }

--- a/frontend/src/pages/CreateEntry.tsx
+++ b/frontend/src/pages/CreateEntry.tsx
@@ -42,10 +42,10 @@ export const CreateEntry = ({ inputType }: Props) => {
   const { forms } = useFormTemplates();
   const { data: tasks } = useTasks(incidentId);
   const navigate = useNavigate();
-  const { mutate: createFormInstance } = useCreateFormInstance(incidentId!, () =>
+  const createFormInstance = useCreateFormInstance(incidentId!, () =>
     navigate(`/logbook/${incidentId}`)
   );
-  const { createLogEntry } = useCreateLogEntry(incidentId, () =>
+  const { createLogEntry, isLoading: isCreatingLogEntry } = useCreateLogEntry(incidentId, () =>
     navigate(`/logbook/${incidentId}`)
   );
   const isOnline = useIsOnline();
@@ -181,7 +181,7 @@ export const CreateEntry = ({ inputType }: Props) => {
 
   const onCustomFormSubmit = () => {
     if (customForm && customFormData) {
-      createFormInstance({
+      createFormInstance.mutate({
         formTemplateId: customForm.id,
         title: customForm.title,
         formData: [...customFormData]
@@ -255,6 +255,7 @@ export const CreateEntry = ({ inputType }: Props) => {
         mentionables={mentionables}
         selectedFiles={selectedFiles}
         recordings={recordings}
+        disableSubmit={isCreatingLogEntry || createFormInstance.isPending}
       />
     </PageWrapper>
   );

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -14,11 +14,13 @@ import { Incident } from './Incident';
 import { MapUtils } from './Map';
 import { Search } from './Search';
 import Validate from './Validate';
+import { mergeOfflineEntities } from './mergeOffline';
 
 const Utils = {
   bem,
   debounce,
   deduplicate,
+  mergeOfflineEntities,
   sortLabel
 };
 
@@ -31,6 +33,7 @@ export {
   Format,
   Icons,
   Incident,
+  mergeOfflineEntities,
   MapUtils,
   Search,
   Utils,

--- a/frontend/src/utils/mergeOffline.ts
+++ b/frontend/src/utils/mergeOffline.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// © Crown Copyright 2025. This work has been developed by the National Digital Twin Programme
+// and is legally attributed to the Department for Business and Trade (UK) as the governing entity.
+
+export type OfflineMergable = { id?: string; offline?: boolean };
+
+export function mergeOfflineEntities<T extends OfflineMergable>(
+  cachedEntities: Array<T> | undefined,
+  entities: Array<T>
+): Array<T> {
+  if (!cachedEntities?.length) return entities;
+
+  const ids: Record<string, boolean> = {};
+  for (const entity of entities) {
+    if (entity.id) ids[entity.id] = true;
+  }
+
+  return [
+    ...cachedEntities.filter((item) => item.offline && item.id && !ids[item.id]),
+    ...entities
+  ];
+}


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

## Motivation and Context

Offline mode wasn't fully working after the changes to how custom forms are created

## Description
- Disable entry form when mutations are pending, this prevents double submits from double clicking and when offline
- Merge offline entries in useLogEntries to prevent losing optimistic inserts when connection is regained
- DRY up some of the offline merging logic

## How Has This Been Tested?
Locally with network throttling

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.