### PR TITLE
feature(non-req): excluded internal objects from av scan

### DIFF
--- a/backend/src/services/fileStorage.ts
+++ b/backend/src/services/fileStorage.ts
@@ -37,18 +37,15 @@ function getContentInfo(
 }
 
 function createS3Client(): S3Client {
-  if (settings.S3_ENDPOINT) {
-    // MinIO
+  if (settings.S3_ENDPOINT) { // MinIO
     return new S3Client({
       endpoint: settings.S3_ENDPOINT,
       forcePathStyle: true,
       region: 'eu-west-2',
-      credentials: settings.S3_ACCESS_KEY_ID
-        ? {
-          accessKeyId: settings.S3_ACCESS_KEY_ID,
-          secretAccessKey: settings.S3_SECRET_ACCESS_KEY
-        }
-        : undefined
+      credentials: settings.S3_ACCESS_KEY_ID ? {
+        accessKeyId: settings.S3_ACCESS_KEY_ID,
+        secretAccessKey: settings.S3_SECRET_ACCESS_KEY
+      } : undefined
     });
   }
 
@@ -58,10 +55,6 @@ function createS3Client(): S3Client {
 export async function getScanResultInternal(key: string) {
   if (!key) {
     throw new ApplicationError('Key cannot be undefined.');
-  }
-
-  if (key.startsWith('internal-')) {
-    return 'N/A';
   }
 
   const client = createS3Client();
@@ -118,7 +111,7 @@ export async function streamS3Object(req: Request, res: Response) {
 
   const scanResult = await getScanResultInternal(key);
 
-  if (scanResult && !['NO_THREATS_FOUND', 'N/A'].includes(scanResult)) {
+  if (scanResult && scanResult !== 'NO_THREATS_FOUND') {
     res.status(400).send('The requested file has been found to be malicious.');
     return;
   }

--- a/frontend/src/components/AttachmentLink.tsx
+++ b/frontend/src/components/AttachmentLink.tsx
@@ -15,8 +15,9 @@ interface Props {
 
 export default function AttachmentLink({ attachment, isOnServer = true }: Readonly<Props>) {
   const { scanResult } = useAttachmentScanResult(attachment.scanResult!, attachment.key!);
-  const scanPendingOrQueuedMessage =
-    'Scanning files for security threats. This process may take a few minutes.';
+  const attachmentPendingMessage = !['Recording', 'Sketch'].includes(attachment.type)
+    ? 'Scanning files for security threats. This process may take a few minutes.'
+    : 'Uploading file.';
 
   if (!isOnServer) {
     return (
@@ -24,15 +25,13 @@ export default function AttachmentLink({ attachment, isOnServer = true }: Readon
         <Typography variant="body1" fontWeight="bold" color="textDisabled">
           {attachment.name}
         </Typography>
-        {!['Recording', 'Sketch'].includes(attachment.type) && (
-          <Typography component="span">{scanPendingOrQueuedMessage}</Typography>
-        )}
+        <Typography component="span">{attachmentPendingMessage}</Typography>
       </Box>
     );
   }
 
   const getUrl = (result: string): string => {
-    if (['N/A', 'NO_THREATS_FOUND'].includes(result)) {
+    if (result === 'NO_THREATS_FOUND') {
       return `/api/files/${attachment.key}/${attachment.name}?mimeType=${encodeURIComponent(attachment.mimeType ?? '')}`;
     }
 
@@ -42,7 +41,7 @@ export default function AttachmentLink({ attachment, isOnServer = true }: Readon
   const getScanStatusDescription = (result: string): string => {
     switch (result) {
       case 'PENDING':
-        return scanPendingOrQueuedMessage;
+        return attachmentPendingMessage;
       case 'THREATS_FOUND':
         return 'This file could not be uploaded due to a security issue. Please try another file.';
       default:
@@ -52,7 +51,7 @@ export default function AttachmentLink({ attachment, isOnServer = true }: Readon
 
   return (
     <Box>
-      {['N/A', 'NO_THREATS_FOUND'].includes(scanResult) ? (
+      {scanResult === 'NO_THREATS_FOUND' ? (
         <Typography
           variant="body1"
           fontWeight="bold"

--- a/frontend/src/hooks/useAttachmentScanResult.ts
+++ b/frontend/src/hooks/useAttachmentScanResult.ts
@@ -12,7 +12,7 @@ export const useAttachmentScanResult = (initialScanResult: string, key: string) 
   useEffect(() => {
     let timeout: ReturnType<typeof setTimeout>;
     const pollScanResult = async (): Promise<void> => {
-      if (['N/A', 'THREATS_FOUND', 'NO_THREATS_FOUND'].includes(initialScanResult)) {
+      if (['THREATS_FOUND', 'NO_THREATS_FOUND'].includes(initialScanResult)) {
         setScanResult(initialScanResult);
         return;
       }


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It was noted while UAT on staging that internal objects like Recordings and Sketches were also being picked up by the AV scanner. These can be excluded as they are created, managed and sent by the system.

## Description
<!--- Describe your changes in detail -->
- Uploaded recording and sketches with the `internal-` prefix
- Uploaded any other attachment with the `external-` prefix
- Updated frontend to replace scan status text with uploading file for sketches and recordings.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested locally and is working as expected.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.