### PR TITLE
feat(DPAV-1767): Add info dialog to offline banner

### DIFF
--- a/frontend/src/components/OfflineBanner.tsx
+++ b/frontend/src/components/OfflineBanner.tsx
@@ -1,47 +1,121 @@
 import { useEffect, useState } from 'react';
 import CloudOffIcon from '@mui/icons-material/CloudOff';
-import { Box, Typography } from '@mui/material';
+import {
+  Box,
+  Typography,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  List,
+  ListItem
+} from '@mui/material';
 import { useIsOnline } from '../hooks/useIsOnline';
 
 export function OfflineBanner() {
   const isOnline = useIsOnline();
   const [visible, setVisible] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
 
   useEffect(() => {
     if (!isOnline) setVisible(true);
     else setTimeout(() => setVisible(false), 500);
   }, [isOnline]);
 
-  if (!visible) return null;
+  if (!visible && !dialogOpen) return null;
 
   return (
-    <Box
-      sx={{
-        width: '100%',
-        backgroundColor: '#938e8e',
-        color: '#fff',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        gap: 1,
-        height: 26,
-        fontSize: '0.75rem',
-        fontWeight: 600,
-        borderBottom: '1px solid #ddd',
-        zIndex: 1,
-        px: 2,
-      }}
-    >
-      <CloudOffIcon sx={{ fontSize: 16, mt: '1px' }} />
-      <Typography
+    <>
+      <Box
         sx={{
+          width: '100%',
+          backgroundColor: '#938e8e',
+          color: '#fff',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 1,
+          height: 26,
           fontSize: '0.75rem',
           fontWeight: 600,
-          lineHeight: 1,
+          borderBottom: '1px solid #ddd',
+          zIndex: 1,
+          px: 2,
+          py: 1.5,
+          position: 'relative'
         }}
       >
-    YOU ARE OFFLINE
-      </Typography>
-    </Box>
+        <CloudOffIcon sx={{ fontSize: 18 }} />
+        <Typography
+          sx={{
+            fontSize: '0.75rem',
+            fontWeight: 600,
+            lineHeight: 1
+          }}
+        >
+          YOU ARE OFFLINE
+        </Typography>
+        <Typography
+          onClick={() => setDialogOpen(true)}
+          sx={{
+            position: 'absolute',
+            right: 12,
+            textDecoration: 'underline',
+            fontSize: '0.75rem',
+            fontWeight: 600,
+            cursor: 'pointer'
+          }}
+        >
+          More Info
+        </Typography>
+      </Box>
+
+      <Dialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        aria-labelledby="offline-dialog-title"
+        fullWidth
+        maxWidth="sm"
+      >
+        <DialogTitle id="offline-dialog-title" sx={{ p: 3 }}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1 }}>
+            <CloudOffIcon sx={{ fontSize: 36 }} />
+            <Typography variant="h5" component="div" sx={{ fontWeight: 700 }}>
+              Offline mode
+            </Typography>
+          </Box>
+        </DialogTitle>
+        <DialogContent>
+          <Typography>
+            Some features need an internet connection and won't be available while you're offline:
+          </Typography>
+          <List
+            dense
+            sx={{
+              py: 2,
+              '& .MuiListItem-root': {
+                listStylePosition: 'inside',
+                listStyleType: 'disc',
+                display: 'list-item'
+              }
+            }}
+          >
+            <ListItem>Sign in / Sign out</ListItem>
+            <ListItem>Real-time notifications</ListItem>
+            <ListItem>Map search & precise location</ListItem>
+            <ListItem>File downloads</ListItem>
+            <ListItem>Changing an incident status</ListItem>
+            <ListItem>Publishing new form templates</ListItem>
+          </List>
+          <Typography>All updates will sync automatically when you're back online.</Typography>
+        </DialogContent>
+        <DialogActions sx={{ p: 3 }}>
+          <Button variant="contained" onClick={() => setDialogOpen(false)}>
+            Close
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
   );
 }


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

Additional info for the user to whats available when offline
https://ndtp.atlassian.net/browse/DPAV-1767

## Description

Adds a more info button and dialog

## How Has This Been Tested?

Locally

## Screenshots (if appropriate):

<img width="437" height="867" alt="Screenshot 2025-09-24 at 10 26 30" src="https://github.com/user-attachments/assets/ae819b79-dcf2-44cd-8fab-893e52a60792" />


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.