### PR TITLE
feat(DPAV-1769): Improve useIncidents query logic/performance

### DIFF
--- a/frontend/src/hooks/useLogEntriesUpdates.tsx
+++ b/frontend/src/hooks/useLogEntriesUpdates.tsx
@@ -71,6 +71,7 @@ export const addOptimisticLogEntry = async (
     [`incident/${incidentId}/logEntries`],
     (oldData) => [optimisticEntry, ...(oldData || [])]
   );
+
   const updatedEntries = [optimisticEntry, ...(previousEntries || [])];
 
   return { previousEntries, updatedEntries };


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

Prevent excess network requests when useIncidents is called
https://ndtp.atlassian.net/browse/DPAV-1769

## Description

- Fetch the log entries from the cache to avoid excess network reqs.
- Set network: 'always' to useIncidents so it won't end up paused, we want it to recalculate each time so it can pick up changes from the offline log entries. We check if we're online before attempting to make a network request, if we're offline we'll use the cache.
- Removed incident cache updating from useLogEntries, this is now applied as we fetch incidents.


## How Has This Been Tested?

Locally

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.