### PR TITLE
feat(DPAV-1773): Disable form template creation when offline

### DIFF
--- a/frontend/src/pages/Forms/FormTemplates.tsx
+++ b/frontend/src/pages/Forms/FormTemplates.tsx
@@ -9,9 +9,11 @@ import { useFormTemplates } from '../../hooks/Forms/useFormTemplates';
 import Format from '../../utils/Format';
 import { PageTitle } from '../../components';
 import PageWrapper from '../../components/PageWrapper';
+import { useIsOnline } from '../../hooks/useIsOnline';
 
 const FormTemplates = () => {
   const navigate = useNavigate();
+  const isOnline = useIsOnline();
   const { forms } = useFormTemplates();
 
   const tableHeaders = ['Form name', 'Created by', 'Date'];
@@ -57,6 +59,7 @@ const FormTemplates = () => {
             startIcon={<AddCircleIcon />}
             variant="contained"
             onClick={handleAddForm}
+            disabled={!isOnline}
             sx={{
               flexBasis: { xs: '48%', md: 'auto' },
               flexGrow: { xs: 1, md: 0 }


### PR DESCRIPTION
## Sensitive Credential Checks
- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

Form creation is not supported yet by the indexdb offline mode (although the mutation is queued by tanstack but won't persist refreshes), its not a requirement at the moment so disabling when offline.

## Description

Disable add/save form template buttons when offline.

## How Has This Been Tested?
Locally

## Screenshots (if appropriate):
<img width="387" height="502" alt="Screenshot 2025-09-29 at 14 44 19" src="https://github.com/user-attachments/assets/ee201499-98ec-45ee-ac09-eda5a8d2bd9d" />


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.